### PR TITLE
Task.015 add to ace-git-worktree create by branch name and pull request id

### DIFF
--- a/.ace-taskflow/v.0.9.0/tasks/done/105-git-worktree-add/105-add-pr-and-branch-based-worktree-creation.s.md
+++ b/.ace-taskflow/v.0.9.0/tasks/done/105-git-worktree-add/105-add-pr-and-branch-based-worktree-creation.s.md
@@ -1,6 +1,6 @@
 ---
 id: v.0.9.0+task.105
-status: pending
+status: done
 priority: medium
 estimate: 3-4 days
 dependencies: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,40 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.125] - 2025-11-13
+
+### Added
+- **ace-git-worktree v0.3.0**: PR and branch-based worktree creation
+  - **NEW**: `--pr <number>` flag to create worktrees from GitHub pull requests
+  - **NEW**: `-b <branch>` flag for worktrees from local/remote branches
+  - GitHub CLI integration with automatic PR metadata fetching
+  - Auto-detection of remote vs. local branches with smart tracking setup
+  - Retry logic with exponential backoff for transient network failures
+  - Fork PR detection with user warnings
+  - Comprehensive test coverage (43 tests total)
+  - Full documentation with usage examples and configuration guide
+
+### Changed
+- **ace-git-worktree v0.3.0**: Enhanced error messages and validation
+  - Error messages now include repository context (e.g., "PR #123 not found in owner/repo")
+  - Configuration validation detects invalid template variables with helpful suggestions
+  - Git remote validation prevents confusing errors from invalid remote names
+  - Code quality improvements with extracted helper methods
+
+### Fixed
+- **ace-git-worktree v0.3.0**: Branch naming collision resolution
+  - Fixed collision issue when multiple remote branches share same last segment
+  - Now uses full branch path: `origin/feature/auth/v1` → branch: `feature/auth/v1`, dir: `feature-auth-v1`
+
 ### Technical
+- **ace-git-worktree v0.3.0**: Architecture and performance improvements
+  - Added `PrFetcher` molecule following ATOM pattern
+  - Cached gh CLI availability check for performance
+  - Extended `WorktreeCreator`, `WorktreeConfig`, and `WorktreeManager`
+  - Template variable support: `{number}`, `{slug}`, `{base_branch}` for PR naming
+  - Repository name caching for better error messages
+  - Configuration validation with comprehensive template variable checking
+  - Remote validation before git fetch operations
 - **ace-git-worktree v0.2.2**: Test suite modernization and command enhancements
   - Simplified test architecture with 843 line reduction (focused smoke tests)
   - Added missing CLI flags (--no-mise-trust, --force)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ PATH
 PATH
   remote: ace-git-worktree
   specs:
-    ace-git-worktree (0.2.2)
+    ace-git-worktree (0.3.0)
       ace-git-diff (>= 0.1.0)
       ace-support-core (>= 0.9.0)
       ace-taskflow (>= 0.10.0)

--- a/ace-git-worktree/CHANGELOG.md
+++ b/ace-git-worktree/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-11-13
+
+### Added
+- **PR-based Worktree Creation**: `--pr <number>` flag to create worktrees from GitHub pull requests
+  - Automatically fetches PR metadata using GitHub CLI (`gh`)
+  - Creates worktree with remote tracking
+  - Detects and warns about fork PRs
+  - Configurable directory and branch naming via `.ace/git/worktree.yml`
+- **Branch-based Worktree Creation**: `-b <branch>` flag for local and remote branches
+  - Auto-detects remote vs. local branches
+  - Automatically fetches remote branches before creation
+  - Sets up tracking for remote branches
+  - Preserves full branch path to avoid naming collisions
+- **PrFetcher Molecule**: GitHub CLI integration with comprehensive error handling
+  - Custom exception classes for clear error types
+  - Timeout support (30s default)
+  - Input validation and security checks
+  - Fork PR detection
+- **Retry Logic**: Automatic retry with exponential backoff for transient network failures
+  - Up to 2 retries by default (configurable)
+  - Smart retry only for NetworkError, not permanent errors
+- **Performance**: Cached gh CLI availability check to avoid repeated system calls
+
+### Changed
+- Extended `WorktreeCreator` with `create_for_pr()` and `create_for_branch()` methods
+- Extended `WorktreeConfig` model with `pr` and `branch` configuration namespaces
+- Extended `WorktreeManager` with `create_pr()` and `create_branch()` orchestration
+- Improved branch naming to use full path and avoid collisions (e.g., `feature/auth/v1` → `feature-auth-v1`)
+- Enhanced CLI help text with PR and branch usage examples
+
+### Fixed
+- Branch name collision issue when multiple remote branches share the same last segment
+  - Changed from `branch.split("/").last` to full branch path preservation
+  - Example: Both `origin/feature/auth/v1` and `origin/login/auth/v1` now create unique worktrees
+
+### Documentation
+- Added "PR and Branch-Based Workflows" section to README
+- Comprehensive usage examples for `--pr` and `-b` options
+- Configuration examples with template variables
+- Requirements and troubleshooting guidance
+
+### Testing
+- Added 12 new unit tests for WorktreeCreator PR/branch methods
+- Added 14 unit tests for PrFetcher molecule
+- Test coverage for happy paths, error scenarios, and edge cases
+
+### Technical
+- Follows ATOM architecture pattern (Atoms → Molecules → Organisms)
+- GitHub CLI (`gh`) is required for PR functionality
+- Supports template variables: `{number}`, `{slug}`, `{base_branch}` for PR naming
+
 ## [0.2.2] - 2025-11-12
 
 ### Changed

--- a/ace-git-worktree/README.md
+++ b/ace-git-worktree/README.md
@@ -37,6 +37,15 @@ gem 'ace-git-worktree'
 # Create a task-aware worktree
 ace-git-worktree create --task 081
 
+# Create a worktree for a GitHub PR
+ace-git-worktree create --pr 26
+
+# Create a worktree from a remote branch
+ace-git-worktree create -b origin/feature/auth
+
+# Create a worktree from a local branch
+ace-git-worktree create -b my-feature
+
 # List all worktrees with task associations
 ace-git-worktree list --show-tasks
 
@@ -49,6 +58,88 @@ ace-git-worktree remove --task 081
 # Clean up deleted worktrees
 ace-git-worktree prune
 ```
+
+## PR and Branch-Based Workflows
+
+**ace-git-worktree** supports creating worktrees directly from GitHub pull requests or specific branches, streamlining code review and feature development workflows.
+
+### PR Worktrees
+
+Create isolated worktrees for reviewing or working on pull requests:
+
+```bash
+# Create worktree for PR #26
+ace-git-worktree create --pr 26
+
+# Alternative syntax
+ace-git-worktree create --pull-request 26
+
+# With dry-run to preview
+ace-git-worktree create --pr 26 --dry-run
+```
+
+**Requirements:**
+- GitHub CLI (`gh`) must be installed and authenticated
+- Run `gh auth login` if not already authenticated
+
+**Features:**
+- Automatically fetches PR metadata and branch information
+- Creates worktree with remote tracking
+- Detects and warns about fork PRs
+- Configurable naming conventions
+
+**Default Behavior:**
+- Directory: `.ace-wt/ace-pr-26/`
+- Branch: `pr-26` tracking `origin/<pr-head-branch>`
+
+### Branch Worktrees
+
+Create worktrees from existing branches (local or remote):
+
+```bash
+# Remote branch (auto-fetches and sets up tracking)
+ace-git-worktree create -b origin/feature/authentication
+ace-git-worktree create --branch upstream/release/v2.0
+
+# Local branch (no tracking)
+ace-git-worktree create -b my-local-feature
+
+# Complex branch names (handles slashes)
+ace-git-worktree create -b origin/feature/auth/oauth2
+```
+
+**Features:**
+- Auto-detects remote vs. local branches
+- Automatically fetches remote branches before creation
+- Sets up tracking for remote branches
+- Preserves full branch path to avoid naming collisions
+
+**Naming:**
+- Remote `origin/feature/auth` → Branch: `feature/auth`, Dir: `feature-auth`
+- Local `my-feature` → Branch: `my-feature`, Dir: `my-feature`
+
+### Configuration
+
+Customize PR and branch worktree behavior in `.ace/git/worktree.yml`:
+
+```yaml
+git:
+  worktree:
+    pr:
+      directory_format: "ace-pr-{number}"  # PR worktree directory
+      branch_format: "pr-{number}"         # Local branch name
+      remote_name: "origin"                # Default remote
+      fetch_before_create: true            # Auto-fetch remote
+
+    branch:
+      fetch_if_remote: true                # Auto-fetch remote branches
+      auto_detect_remote: true             # Auto-detect remote vs local
+```
+
+**Template Variables for PR Format:**
+- `{number}` - PR number (e.g., `26`)
+- `{slug}` - Slugified PR title (e.g., `add-authentication`)
+- `{base_branch}` - Base branch name (e.g., `main`)
 
 ## Task-Aware Workflow
 

--- a/ace-git-worktree/lib/ace/git/worktree/commands/create_command.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/commands/create_command.rb
@@ -39,6 +39,10 @@ module Ace
 
               if options[:task]
                 create_task_worktree(options)
+              elsif options[:pr]
+                create_pr_worktree(options)
+              elsif options[:branch]
+                create_branch_worktree(options)
               else
                 create_traditional_worktree(options)
               end
@@ -63,18 +67,31 @@ module Ace
               USAGE:
                   ace-git-worktree create <branch-name> [OPTIONS]
                   ace-git-worktree create --task <task-id> [OPTIONS]
+                  ace-git-worktree create --pr <pr-number> [OPTIONS]
+                  ace-git-worktree create --branch <branch> [OPTIONS]
 
               TASK-AWARE CREATION:
                   --task <task-id>         Create worktree for a specific task
                                          Task ID formats: 081, task.081, v.0.9.0+081
 
+              PR-AWARE CREATION:
+                  --pr <number>           Create worktree for a GitHub pull request
+                  --pull-request <number> (alias for --pr)
+                                         Requires gh CLI to be installed and authenticated
+
+              BRANCH-AWARE CREATION:
+                  -b <branch>             Create worktree from a branch (local or remote)
+                  --branch <branch>       (alias for -b)
+                                         Remote branches: origin/feature, upstream/main
+                                         Local branches: feature-name
+
               OPTIONS:
                   --path <path>           Custom worktree path (default: from config)
                   --dry-run               Show what would be created without creating
-                  --no-status-update      Skip marking task as in-progress
-                  --no-commit             Skip committing task changes
+                  --no-status-update      Skip marking task as in-progress (task mode only)
+                  --no-commit             Skip committing task changes (task mode only)
                   --no-auto-navigate      Stay in current directory (default: navigate to worktree)
-                  --commit-message <msg>  Custom commit message for task updates
+                  --commit-message <msg>  Custom commit message for task updates (task mode only)
                   --force                 Create even if worktree already exists
                   --help, -h              Show this help message
 
@@ -82,20 +99,33 @@ module Ace
                   # Create task-aware worktree
                   ace-git-worktree create --task 081
 
+                  # Create PR worktree
+                  ace-git-worktree create --pr 26
+
+                  # Create worktree from remote branch
+                  ace-git-worktree create -b origin/feature/auth
+
+                  # Create worktree from local branch
+                  ace-git-worktree create -b my-feature
+
                   # Create traditional worktree
                   ace-git-worktree create feature-branch
 
                   # Custom path and dry run
-                  ace-git-worktree create --task 081 --path ~/worktrees --dry-run
-
-                  # Skip automatic actions
-                  ace-git-worktree create --task 081 --no-status-update
+                  ace-git-worktree create --pr 26 --path ~/worktrees --dry-run
 
               CONFIGURATION:
                   Worktree creation is controlled by .ace/git/worktree.yml:
                   - root_path: Default worktree root directory
                   - task.auto_*: Automation settings for task workflows
+                  - pr.directory_format: PR worktree naming format (default: ace-pr-{number})
+                  - pr.branch_format: PR branch naming format (default: pr-{number})
                   - hooks.after_create: Commands to run after worktree creation
+
+              REQUIREMENTS:
+                  PR-aware creation requires GitHub CLI (gh):
+                  - Install: brew install gh
+                  - Authenticate: gh auth login
             HELP
             0
           end
@@ -109,6 +139,8 @@ module Ace
           def parse_arguments(args)
             options = {
               task: nil,
+              pr: nil,
+              branch: nil,
               path: nil,
               dry_run: false,
               no_status_update: false,
@@ -127,6 +159,12 @@ module Ace
               when "--task"
                 i += 1
                 options[:task] = args[i]
+              when "--pr", "--pull-request"
+                i += 1
+                options[:pr] = args[i]
+              when "-b", "--branch"
+                i += 1
+                options[:branch] = args[i]
               when "--path"
                 i += 1
                 options[:path] = args[i]
@@ -163,24 +201,57 @@ module Ace
             options
           end
 
+          # Detect which creation mode(s) are specified
+          #
+          # @param options [Hash] Parsed options
+          # @return [Array<Symbol>] List of detected modes (:task, :pr, :branch, :traditional)
+          def detect_creation_modes(options)
+            modes = []
+            modes << :task if options[:task]
+            modes << :pr if options[:pr]
+            modes << :branch if options[:branch]
+            modes << :traditional if options[:branch_name]
+            modes
+          end
+
           # Validate parsed options
           #
           # @param options [Hash] Parsed options
           def validate_options(options)
-            if options[:task] && options[:branch_name]
-              raise ArgumentError, "Cannot specify both --task and branch name"
+            # Detect creation modes
+            modes = detect_creation_modes(options)
+
+            # Check for conflicts
+            if modes.length > 1
+              raise ArgumentError, "Cannot use multiple creation modes: #{modes.join(', ')}. " \
+                                   "Use only one of --task, --pr, --branch, or <branch-name>"
             end
 
-            if !options[:task] && !options[:branch_name]
-              raise ArgumentError, "Must specify either --task <task-id> or <branch-name>"
+            # Require at least one mode
+            if modes.empty?
+              raise ArgumentError, "Must specify either --task <task-id>, --pr <number>, --branch <branch>, or <branch-name>"
             end
 
+            # Validate each mode's input
             if options[:task] && options[:task].empty?
               raise ArgumentError, "Task ID cannot be empty"
             end
 
+            if options[:pr] && options[:pr].empty?
+              raise ArgumentError, "PR number cannot be empty"
+            end
+
+            if options[:branch] && options[:branch].empty?
+              raise ArgumentError, "Branch name cannot be empty"
+            end
+
             if options[:branch_name] && options[:branch_name].empty?
               raise ArgumentError, "Branch name cannot be empty"
+            end
+
+            # Validate PR number is numeric
+            if options[:pr] && !options[:pr].match?(/^\d+$/)
+              raise ArgumentError, "PR number must be a positive integer"
             end
 
             if options[:commit_message] && options[:commit_message].empty?
@@ -274,6 +345,140 @@ module Ace
             end
           end
 
+          # Create a PR worktree
+          #
+          # @param options [Hash] Command options
+          # @return [Integer] Exit code
+          def create_pr_worktree(options)
+            @options = options
+            pr_number = options[:pr].to_i
+            puts "Creating worktree for PR ##{pr_number}..."
+
+            # Check gh CLI availability
+            require_relative "../molecules/pr_fetcher"
+            fetcher = Molecules::PrFetcher.new
+
+            unless fetcher.gh_available?
+              puts "Error: gh CLI is required for PR worktree creation."
+              puts
+              puts fetcher.gh_not_available_message
+              return 1
+            end
+
+            # Fetch PR data
+            puts "Fetching PR information..."
+            begin
+              pr_data = fetcher.fetch(pr_number)
+
+              # Display fork warning if applicable
+              if pr_data[:is_cross_repository]
+                puts "⚠️  This PR is from a fork"
+                puts "   Repository owner: #{pr_data[:head_repository_owner]}" if pr_data[:head_repository_owner]
+                puts
+              end
+
+              # Show PR details
+              puts "PR ##{pr_data[:number]}: #{pr_data[:title]}"
+              puts "Branch: #{pr_data[:head_branch]} -> #{pr_data[:base_branch]}"
+              puts
+
+              # Prepare creation options
+              creation_options = {
+                path: options[:path],
+                dry_run: options[:dry_run],
+                no_mise_trust: options[:no_mise_trust],
+                force: options[:force]
+              }.compact
+
+              # Create the worktree
+              result = @manager.create_pr(pr_number, pr_data, creation_options)
+
+              if result[:success]
+                display_pr_creation_result(result, options[:dry_run])
+                0
+              else
+                puts "Failed to create worktree: #{result[:error]}"
+                display_warnings(result[:warnings]) if result[:warnings]
+                1
+              end
+            rescue Molecules::PrFetcher::PrNotFoundError => e
+              puts "Error: #{e.message}"
+              puts
+              puts "Suggestions:"
+              puts "  1. Verify the PR number is correct"
+              puts "  2. Check if the PR exists: gh pr view #{pr_number}"
+              puts "  3. Ensure you're in the correct repository"
+              1
+            rescue Molecules::PrFetcher::NetworkError => e
+              puts "Error: #{e.message}"
+              puts
+              puts "Troubleshooting:"
+              puts "  1. Check your internet connection"
+              puts "  2. Verify GitHub authentication: gh auth status"
+              puts "  3. Re-authenticate if needed: gh auth login"
+              1
+            end
+          end
+
+          # Create a branch worktree
+          #
+          # @param options [Hash] Command options
+          # @return [Integer] Exit code
+          def create_branch_worktree(options)
+            @options = options
+            branch_name = options[:branch]
+            puts "Creating worktree for branch: #{branch_name}..."
+
+            # Detect if remote branch
+            require_relative "../molecules/worktree_creator"
+            creator = Molecules::WorktreeCreator.new
+            remote_info = creator.send(:detect_remote_branch, branch_name)
+
+            if remote_info
+              puts "Detected remote branch: #{remote_info[:remote]}/#{remote_info[:branch]}"
+              puts "Will create with tracking..."
+            else
+              puts "Creating worktree from local branch..."
+            end
+            puts
+
+            # Prepare creation options
+            creation_options = {
+              path: options[:path],
+              dry_run: options[:dry_run],
+              no_mise_trust: options[:no_mise_trust],
+              force: options[:force]
+            }.compact
+
+            # Create the worktree
+            result = @manager.create_branch(branch_name, creation_options)
+
+            if result[:success]
+              display_branch_creation_result(result, options[:dry_run])
+              0
+            else
+              puts "Failed to create worktree: #{result[:error]}"
+              display_warnings(result[:warnings]) if result[:warnings]
+
+              # Provide helpful guidance
+              if result[:error]&.include?("not found")
+                puts
+                puts "Branch not found suggestions:"
+                if remote_info
+                  puts "  1. Fetch the remote: git fetch #{remote_info[:remote]}"
+                  puts "  2. List remote branches: git branch -r"
+                  puts "  3. Verify branch name: git ls-remote #{remote_info[:remote]}"
+                else
+                  puts "  1. List local branches: git branch"
+                  puts "  2. Create the branch: git branch #{branch_name}"
+                  puts "  3. Or use a remote branch: -b origin/#{branch_name}"
+                end
+              end
+
+              1
+            end
+          end
+
           # Check if task dependencies are available with helpful messages
           #
           # @return [Hash] { available: boolean, message: string }
@@ -361,6 +566,97 @@ module Ace
             # Display cd command for user to execute
             unless dry_run
               puts ""
+              puts "cd #{result[:worktree_path]}"
+            end
+          end
+
+          # Display PR worktree creation result
+          #
+          # @param result [Hash] Creation result
+          # @param dry_run [Boolean] Whether this was a dry run
+          def display_pr_creation_result(result, dry_run = false)
+            if dry_run
+              puts "\nDry run - no changes made:"
+              puts "Would create worktree at: #{result[:would_create][:worktree_path]}"
+              puts "Would create branch: #{result[:would_create][:branch]}"
+              puts "Would track: #{result[:would_create][:tracking]}"
+              puts "PR: ##{result[:pr_number]} - #{result[:pr_title]}"
+            else
+              puts "\nWorktree created successfully!"
+              puts "✓ PR ##{result[:pr_number]}: #{result[:pr_title]}" if result[:pr_title]
+              puts "✓ Remote branch: #{result[:tracking]}" if result[:tracking]
+              puts "✓ Created worktree: #{result[:directory_name]}" if result[:directory_name]
+              puts "✓ Branch: #{result[:branch]} tracking #{result[:tracking]}"
+              puts "✓ Location: #{result[:worktree_path]}"
+              puts
+
+              # Display hooks results if available
+              if result[:hooks_results] && result[:hooks_results].any?
+                puts "Hooks executed:"
+                result[:hooks_results].each do |hook_result|
+                  status = hook_result[:success] ? "✓" : "✗"
+                  command = hook_result[:command].length > 60 ? "#{hook_result[:command][0..57]}..." : hook_result[:command]
+                  puts "  #{status} #{command}"
+                  unless hook_result[:success]
+                    puts "    Error: #{hook_result[:error]}" if hook_result[:error]
+                  end
+                end
+                puts
+              end
+            end
+
+            display_warnings(result[:warnings]) if result[:warnings]
+
+            # Display cd command for user to execute
+            unless dry_run
+              puts "cd #{result[:worktree_path]}"
+            end
+          end
+
+          # Display branch worktree creation result
+          #
+          # @param result [Hash] Creation result
+          # @param dry_run [Boolean] Whether this was a dry run
+          def display_branch_creation_result(result, dry_run = false)
+            if dry_run
+              puts "\nDry run - no changes made:"
+              puts "Would create worktree at: #{result[:would_create][:worktree_path]}"
+              puts "Would create branch: #{result[:would_create][:branch]}"
+              if result[:would_create][:tracking]
+                puts "Would track: #{result[:would_create][:tracking]}"
+              else
+                puts "Local branch (no tracking)"
+              end
+            else
+              puts "\nWorktree created successfully!"
+              puts "✓ Created worktree: #{result[:directory_name]}" if result[:directory_name]
+              if result[:tracking]
+                puts "✓ Branch: #{result[:branch]} tracking #{result[:tracking]}"
+              else
+                puts "✓ Branch: #{result[:branch]} (local, no tracking)"
+              end
+              puts "✓ Location: #{result[:worktree_path]}"
+              puts
+
+              # Display hooks results if available
+              if result[:hooks_results] && result[:hooks_results].any?
+                puts "Hooks executed:"
+                result[:hooks_results].each do |hook_result|
+                  status = hook_result[:success] ? "✓" : "✗"
+                  command = hook_result[:command].length > 60 ? "#{hook_result[:command][0..57]}..." : hook_result[:command]
+                  puts "  #{status} #{command}"
+                  unless hook_result[:success]
+                    puts "    Error: #{hook_result[:error]}" if hook_result[:error]
+                  end
+                end
+                puts
+              end
+            end
+
+            display_warnings(result[:warnings]) if result[:warnings]
+
+            # Display cd command for user to execute
+            unless dry_run
               puts "cd #{result[:worktree_path]}"
             end
           end

--- a/ace-git-worktree/lib/ace/git/worktree/models/worktree_config.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/models/worktree_config.rb
@@ -36,6 +36,16 @@ module Ace
               "commit_message_format" => "chore({release}-{task_id}): mark as in-progress, creating worktree for {slug}",
               "add_worktree_metadata" => true
             },
+            "pr" => {
+              "directory_format" => "ace-pr-{number}",
+              "branch_format" => "pr-{number}",
+              "remote_name" => "origin",
+              "fetch_before_create" => true
+            },
+            "branch" => {
+              "fetch_if_remote" => true,
+              "auto_detect_remote" => true
+            },
             "cleanup" => {
               "on_merge" => false,
               "on_delete" => true
@@ -48,7 +58,7 @@ module Ace
           # Configuration namespace paths
           CONFIG_NAMESPACE = ["git", "worktree"].freeze
 
-          attr_reader :root_path, :auto_navigate, :mise_trust_auto, :task_config, :cleanup_config, :hooks_config
+          attr_reader :root_path, :auto_navigate, :mise_trust_auto, :task_config, :pr_config, :branch_config, :cleanup_config, :hooks_config
 
           # Initialize a new WorktreeConfig
           #
@@ -208,26 +218,50 @@ module Ace
               errors << "root_path must be a non-empty string"
             end
 
-            # Validate template formats
+            # Validate task template formats
             unless directory_format.is_a?(String) && !directory_format.empty?
-              errors << "directory_format must be a non-empty string"
+              errors << "task.directory_format must be a non-empty string"
             end
 
             unless branch_format.is_a?(String) && !branch_format.empty?
-              errors << "branch_format must be a non-empty string"
+              errors << "task.branch_format must be a non-empty string"
             end
 
-            # Validate template variables
-            templates_with_requirements = {
-              directory_format => [%w[task_id], directory_format],
-              branch_format => [%w[id slug], branch_format],
-              commit_message_format => [%w[release task_id slug], commit_message_format]
+            # Validate PR template formats
+            pr_dir_format = @pr_config["directory_format"]
+            unless pr_dir_format.is_a?(String) && !pr_dir_format.empty?
+              errors << "pr.directory_format must be a non-empty string"
+            end
+
+            pr_branch_format = @pr_config["branch_format"]
+            unless pr_branch_format.is_a?(String) && !pr_branch_format.empty?
+              errors << "pr.branch_format must be a non-empty string"
+            end
+
+            # Validate template variables for task configuration
+            task_templates = {
+              "task.directory_format" => { template: directory_format, valid_vars: %w[task_id id slug release] },
+              "task.branch_format" => { template: branch_format, valid_vars: %w[id slug task_id release] },
+              "task.commit_message_format" => { template: commit_message_format, valid_vars: %w[release task_id slug id] }
             }
 
-            templates_with_requirements.each do |template_key, (required_vars, template_value)|
-              missing_vars = required_vars.reject { |var| template_value.include?("{#{var}}") }
-              if missing_vars.any?
-                errors << "#{template_value} should include common template variables: #{missing_vars.join(', ')}"
+            task_templates.each do |name, config|
+              invalid_vars = find_invalid_template_variables(config[:template], config[:valid_vars])
+              if invalid_vars.any?
+                errors << "#{name} contains invalid variables: #{invalid_vars.join(', ')}. Valid variables: #{config[:valid_vars].map { |v| "{#{v}}" }.join(', ')}"
+              end
+            end
+
+            # Validate template variables for PR configuration
+            pr_templates = {
+              "pr.directory_format" => { template: pr_dir_format, valid_vars: %w[number slug title base_branch] },
+              "pr.branch_format" => { template: pr_branch_format, valid_vars: %w[number slug title base_branch] }
+            }
+
+            pr_templates.each do |name, config|
+              invalid_vars = find_invalid_template_variables(config[:template], config[:valid_vars])
+              if invalid_vars.any?
+                errors << "#{name} contains invalid variables: #{invalid_vars.join(', ')}. Valid variables: #{config[:valid_vars].map { |v| "{#{v}}" }.join(', ')}"
               end
             end
 
@@ -249,6 +283,21 @@ module Ace
           end
 
           private
+
+          # Find invalid template variables in a template string
+          #
+          # @param template [String] Template string with {variable} placeholders
+          # @param valid_vars [Array<String>] List of valid variable names
+          # @return [Array<String>] List of invalid variable names
+          def find_invalid_template_variables(template, valid_vars)
+            return [] unless template.is_a?(String)
+
+            # Extract all variables from template
+            template_vars = template.scan(/\{(\w+)\}/).flatten
+
+            # Find variables that are not in the valid list
+            template_vars.uniq.reject { |var| valid_vars.include?(var) }
+          end
 
           # Extract worktree configuration from nested config hash
           #
@@ -289,6 +338,8 @@ module Ace
             @auto_navigate = @merged_config["auto_navigate"]
             @mise_trust_auto = @merged_config["mise_trust_auto"]
             @task_config = @merged_config["task"] || {}
+            @pr_config = @merged_config["pr"] || {}
+            @branch_config = @merged_config["branch"] || {}
             @cleanup_config = @merged_config["cleanup"] || {}
             @hooks_config = @merged_config["hooks"] || {}
           end

--- a/ace-git-worktree/lib/ace/git/worktree/molecules/pr_fetcher.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/molecules/pr_fetcher.rb
@@ -1,0 +1,284 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+
+module Ace
+  module Git
+    module Worktree
+      module Molecules
+        # PR fetcher molecule
+        #
+        # Fetches pull request data from GitHub using the gh CLI.
+        # Provides a simple interface for retrieving PR information.
+        #
+        # @example Fetch PR data
+        #   fetcher = PrFetcher.new
+        #   pr = fetcher.fetch(26)
+        #   pr[:title] # => "Add authentication feature"
+        #
+        # @example Handle non-existent PR
+        #   pr = fetcher.fetch(999)
+        #   pr # => nil
+        class PrFetcher
+          # Error raised when gh CLI is not available
+          class GhNotAvailableError < StandardError; end
+
+          # Error raised when PR is not found
+          class PrNotFoundError < StandardError; end
+
+          # Error raised on network/timeout issues
+          class NetworkError < StandardError; end
+
+          # Initialize a new PrFetcher
+          #
+          # @param timeout [Integer] Timeout in seconds (default: 30)
+          # @param max_retries [Integer] Maximum number of retry attempts for transient failures (default: 2)
+          def initialize(timeout: 30, max_retries: 2)
+            @timeout = timeout
+            @max_retries = max_retries
+          end
+
+          # Fetch PR data by number
+          #
+          # @param pr_number [Integer, String] PR number
+          # @return [Hash, nil] PR data hash or nil if not found
+          # @raise [GhNotAvailableError] if gh CLI is not installed
+          # @raise [PrNotFoundError] if PR doesn't exist
+          # @raise [NetworkError] if network request fails
+          #
+          # @example
+          #   fetcher = PrFetcher.new
+          #   pr = fetcher.fetch(26)
+          #   pr[:number] # => 26
+          #   pr[:title] # => "Add authentication feature"
+          #   pr[:head_branch] # => "feature/auth"
+          #   pr[:base_branch] # => "main"
+          def fetch(pr_number)
+            verify_gh_available!
+
+            # Validate input
+            pr_num = validate_pr_number(pr_number)
+            return nil unless pr_num
+
+            # Fetch PR data via gh CLI
+            fetch_via_gh(pr_num)
+          rescue GhNotAvailableError, PrNotFoundError, NetworkError
+            raise
+          rescue StandardError => e
+            raise NetworkError, "Failed to fetch PR: #{e.message}"
+          end
+
+          # Check if gh CLI is available (cached)
+          #
+          # @return [Boolean] true if gh is installed and accessible
+          def gh_available?
+            return @gh_available unless @gh_available.nil?
+
+            @gh_available = system("which gh > /dev/null 2>&1")
+          end
+
+          # Verify gh CLI is available, raise error if not
+          #
+          # @raise [GhNotAvailableError] if gh is not available
+          # @return [void]
+          def verify_gh_available!
+            return if gh_available?
+
+            raise GhNotAvailableError, gh_not_available_message
+          end
+
+          # Get helpful error message when gh CLI is unavailable
+          #
+          # @return [String] User-friendly error message with installation guidance
+          def gh_not_available_message
+            <<~MESSAGE
+              gh CLI is required for PR worktrees but is not installed.
+
+              Install gh CLI:
+              - macOS: brew install gh
+              - Linux: See https://github.com/cli/cli#installation
+              - Windows: See https://github.com/cli/cli#installation
+
+              After installation, authenticate with: gh auth login
+            MESSAGE
+          end
+
+          private
+
+          # Validate PR number
+          #
+          # @param pr_number [Integer, String] PR number to validate
+          # @return [Integer, nil] Validated PR number or nil if invalid
+          def validate_pr_number(pr_number)
+            # Convert to string and strip whitespace
+            pr_str = pr_number.to_s.strip
+
+            # Check if it's a positive integer
+            return nil unless pr_str.match?(/^\d+$/)
+
+            num = pr_str.to_i
+            return nil if num <= 0 || num > 999999 # Reasonable upper bound
+
+            num
+          end
+
+          # Fetch PR data via gh CLI with retry logic
+          #
+          # @param pr_number [Integer] Valid PR number
+          # @return [Hash] PR data hash
+          # @raise [PrNotFoundError] if PR doesn't exist
+          # @raise [NetworkError] if network request fails after retries
+          def fetch_via_gh(pr_number)
+            attempt = 0
+            last_error = nil
+
+            loop do
+              begin
+                return fetch_via_gh_once(pr_number)
+              rescue PrNotFoundError
+                # Don't retry for PR not found (permanent error)
+                raise
+              rescue NetworkError => e
+                attempt += 1
+                last_error = e
+
+                # If we've exhausted retries, raise the last error
+                if attempt > @max_retries
+                  raise last_error
+                end
+
+                # Wait with exponential backoff before retry
+                sleep(calculate_retry_delay(attempt))
+                # Retry the request
+              end
+            end
+          end
+
+          # Calculate retry delay using exponential backoff
+          #
+          # @param attempt [Integer] Current attempt number (1-based)
+          # @return [Integer] Delay in seconds (1s, 2s, 4s, 8s, ...)
+          def calculate_retry_delay(attempt)
+            2**(attempt - 1)
+          end
+
+          # Fetch PR data via gh CLI (single attempt)
+          #
+          # @param pr_number [Integer] Valid PR number
+          # @return [Hash] PR data hash
+          # @raise [PrNotFoundError] if PR doesn't exist
+          # @raise [NetworkError] if network request fails
+          def fetch_via_gh_once(pr_number)
+            # Get repository context for better error messages
+            repo_name = get_repository_name
+
+            # Fields to fetch from GitHub
+            fields = %w[
+              number
+              headRefName
+              baseRefName
+              title
+              headRepositoryOwner
+              isCrossRepository
+            ]
+
+            # Build gh command
+            cmd = ["gh", "pr", "view", pr_number.to_s, "--json", fields.join(",")]
+
+            # Execute with timeout
+            stdout, stderr, status = execute_with_timeout(cmd, @timeout)
+
+            # Handle errors
+            unless status.success?
+              handle_gh_error(pr_number, stderr, repo_name)
+            end
+
+            # Parse JSON response
+            parse_pr_json(stdout, pr_number)
+          rescue JSON::ParserError => e
+            raise NetworkError, "Failed to parse GitHub response: #{e.message}"
+          end
+
+          # Execute command with timeout
+          #
+          # @param cmd [Array<String>] Command and arguments
+          # @param timeout [Integer] Timeout in seconds
+          # @return [Array<String, String, Process::Status>] stdout, stderr, status
+          def execute_with_timeout(cmd, timeout)
+            require "timeout"
+
+            Timeout.timeout(timeout) do
+              Open3.capture3(*cmd)
+            end
+          rescue Timeout::Error
+            raise NetworkError, "Request timed out after #{timeout} seconds. Check your network connection."
+          end
+
+          # Get repository name for error messages
+          #
+          # @return [String, nil] Repository name (e.g., "owner/repo") or nil if not available
+          def get_repository_name
+            return @repository_name if defined?(@repository_name)
+
+            # Try to get repo name from gh CLI
+            stdout, _stderr, status = Open3.capture3("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
+            @repository_name = status.success? ? stdout.strip : nil
+          rescue StandardError
+            @repository_name = nil
+          end
+
+          # Handle gh CLI errors
+          #
+          # @param pr_number [Integer] PR number
+          # @param stderr [String] Error output from gh
+          # @param repo_name [String, nil] Repository name for context
+          # @raise [PrNotFoundError, NetworkError] Appropriate error based on stderr
+          def handle_gh_error(pr_number, stderr, repo_name = nil)
+            error_msg = stderr.downcase
+
+            if error_msg.include?("could not resolve to a pullrequest") ||
+               error_msg.include?("not found") ||
+               error_msg.include?("no pull requests")
+              repo_context = repo_name ? " in #{repo_name}" : " in this repository"
+              raise PrNotFoundError, "PR ##{pr_number} not found#{repo_context}"
+            elsif error_msg.include?("authentication") || error_msg.include?("auth")
+              raise NetworkError, "GitHub CLI not authenticated. Run: gh auth login"
+            elsif error_msg.include?("network") || error_msg.include?("connection")
+              raise NetworkError, "Network error. Check your connection and try again."
+            else
+              raise NetworkError, "GitHub CLI error: #{stderr}"
+            end
+          end
+
+          # Parse PR JSON response
+          #
+          # @param json_str [String] JSON string from gh CLI
+          # @param pr_number [Integer] PR number for validation
+          # @return [Hash] Parsed PR data
+          # @raise [NetworkError] if data is invalid
+          def parse_pr_json(json_str, pr_number)
+            data = JSON.parse(json_str)
+
+            # Validate required fields
+            required = ["number", "headRefName", "baseRefName", "title"]
+            missing = required - data.keys
+            unless missing.empty?
+              raise NetworkError, "Invalid PR data: missing fields #{missing.join(', ')}"
+            end
+
+            # Convert to our internal format
+            {
+              number: data["number"],
+              title: data["title"],
+              head_branch: data["headRefName"],
+              base_branch: data["baseRefName"],
+              is_cross_repository: data["isCrossRepository"] || false,
+              head_repository_owner: data.dig("headRepositoryOwner", "login")
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/ace-git-worktree/lib/ace/git/worktree/molecules/worktree_creator.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/molecules/worktree_creator.rb
@@ -83,6 +83,112 @@ module Ace
             end
           end
 
+          # Create a worktree for a Pull Request
+          #
+          # @param pr_data [Hash] PR data hash from PrFetcher
+          # @param config [WorktreeConfig] Worktree configuration
+          # @param git_root [String, nil] Git repository root (auto-detected if nil)
+          # @return [Hash] Result with :success, :worktree_path, :branch, :error
+          #
+          # @example
+          #   pr_data = { number: 26, title: "Add feature", head_branch: "feature/auth", base_branch: "main" }
+          #   result = creator.create_for_pr(pr_data, config)
+          #   # => { success: true, worktree_path: "/project/.ace-wt/pr-26", branch: "pr-26", tracking: "origin/feature/auth" }
+          def create_for_pr(pr_data, config, git_root: nil)
+            return error_result("PR data is required") unless pr_data
+            return error_result("Configuration is required") unless config
+
+            begin
+              # Determine git repository root
+              git_root ||= detect_git_root
+              return error_result("Not in a git repository") unless git_root
+
+              # Get PR-specific configuration (fallback to defaults)
+              pr_config = config.pr_config || {}
+              remote_name = pr_config[:remote_name] || "origin"
+              directory_format = pr_config[:directory_format] || "ace-pr-{number}"
+              branch_format = pr_config[:branch_format] || "pr-{number}"
+
+              # Format directory and branch names
+              directory_name = format_pr_name(directory_format, pr_data)
+              local_branch_name = format_pr_name(branch_format, pr_data)
+
+              # Build full path
+              worktree_path = File.join(config.absolute_root_path, directory_name)
+
+              # Validate worktree path
+              validation = validate_worktree_path(worktree_path, git_root)
+              return error_result(validation[:error]) unless validation[:valid]
+
+              # Fetch the remote branch
+              head_branch = pr_data[:head_branch]
+              fetch_result = fetch_remote_branch(remote_name, head_branch, git_root)
+              return error_result(fetch_result[:error]) unless fetch_result[:success]
+
+              # Create worktree with remote tracking
+              result = create_worktree_with_tracking(
+                worktree_path,
+                local_branch_name,
+                "#{remote_name}/#{head_branch}",
+                git_root
+              )
+              return result unless result[:success]
+
+              # Success - return worktree information
+              {
+                success: true,
+                worktree_path: worktree_path,
+                branch: local_branch_name,
+                tracking: "#{remote_name}/#{head_branch}",
+                directory_name: directory_name,
+                pr_number: pr_data[:number],
+                pr_title: pr_data[:title],
+                git_root: git_root,
+                error: nil
+              }
+            rescue StandardError => e
+              error_result("Unexpected error: #{e.message}")
+            end
+          end
+
+          # Create a worktree for a specific branch (local or remote)
+          #
+          # @param branch_name [String] Branch name (e.g., "feature" or "origin/feature")
+          # @param config [WorktreeConfig] Worktree configuration
+          # @param git_root [String, nil] Git repository root (auto-detected if nil)
+          # @return [Hash] Result with :success, :worktree_path, :branch, :error
+          #
+          # @example Remote branch
+          #   result = creator.create_for_branch("origin/feature/auth", config)
+          #   # => { success: true, worktree_path: "/project/.ace-wt/feature-auth", branch: "feature/auth", tracking: "origin/feature/auth" }
+          #
+          # @example Local branch
+          #   result = creator.create_for_branch("local-feature", config)
+          #   # => { success: true, worktree_path: "/project/.ace-wt/local-feature", branch: "local-feature", tracking: nil }
+          def create_for_branch(branch_name, config, git_root: nil)
+            return error_result("Branch name is required") if branch_name.nil? || branch_name.empty?
+            return error_result("Configuration is required") unless config
+
+            begin
+              # Determine git repository root
+              git_root ||= detect_git_root
+              return error_result("Not in a git repository") unless git_root
+
+              # Detect if this is a remote branch
+              remote_info = detect_remote_branch(branch_name)
+
+              if remote_info
+                # Remote branch - create with tracking
+                create_for_remote_branch(branch_name, remote_info, config, git_root)
+              else
+                # Local branch - create without tracking
+                create_for_local_branch(branch_name, config, git_root)
+              end
+            rescue StandardError => e
+              error_result("Unexpected error: #{e.message}")
+            end
+          end
+
           # Create a traditional worktree (not task-aware)
           #
           # @param branch_name [String] Branch name
@@ -314,6 +420,254 @@ module Ace
               branch: nil,
               error: message
             }
+          end
+
+          # Detect if a branch name refers to a remote branch
+          #
+          # @param branch_name [String] Branch name to check
+          # @return [Hash, nil] { remote: "origin", branch: "feature/auth" } or nil if local
+          #
+          # @example
+          #   detect_remote_branch("origin/feature/auth")
+          #   # => { remote: "origin", branch: "feature/auth" }
+          #
+          #   detect_remote_branch("local-branch")
+          #   # => nil
+          def detect_remote_branch(branch_name)
+            # Check if branch name contains a slash (remote/branch pattern)
+            return nil unless branch_name.include?("/")
+
+            # Split on first slash only
+            parts = branch_name.split("/", 2)
+            return nil if parts.length != 2
+
+            remote = parts[0]
+            branch = parts[1]
+
+            # Basic validation
+            return nil if remote.empty? || branch.empty?
+
+            { remote: remote, branch: branch }
+          end
+
+          # Validate that a git remote exists
+          #
+          # @param remote [String] Remote name (e.g., "origin")
+          # @param git_root [String] Git repository root
+          # @return [Hash] Result with :exists (Boolean) and :remotes (Array) for helpful error messages
+          def validate_remote_exists(remote, git_root)
+            require_relative "../atoms/git_command"
+
+            # Get list of remotes
+            result = Atoms::GitCommand.execute(
+              ["remote"],
+              timeout: 5
+            )
+
+            if result[:success]
+              remotes = result[:output].strip.split("\n")
+              exists = remotes.include?(remote)
+              { exists: exists, remotes: remotes }
+            else
+              # If we can't list remotes, assume it doesn't exist
+              { exists: false, remotes: [] }
+            end
+          end
+
+          # Fetch a remote branch
+          #
+          # @param remote [String] Remote name (e.g., "origin")
+          # @param branch [String] Branch name
+          # @param git_root [String] Git repository root
+          # @return [Hash] Result with :success, :error
+          def fetch_remote_branch(remote, branch, git_root)
+            require_relative "../atoms/git_command"
+
+            # Validate remote exists first
+            validation = validate_remote_exists(remote, git_root)
+            unless validation[:exists]
+              available = validation[:remotes].empty? ? "no remotes configured" : validation[:remotes].join(", ")
+              return {
+                success: false,
+                error: "Remote '#{remote}' not found. Available remotes: #{available}"
+              }
+            end
+
+            result = Atoms::GitCommand.execute(
+              ["fetch", remote, branch],
+              timeout: @timeout
+            )
+
+            if result[:success]
+              { success: true, error: nil }
+            else
+              { success: false, error: "Failed to fetch #{remote}/#{branch}: #{result[:error]}" }
+            end
+          end
+
+          # Create a worktree with remote tracking
+          #
+          # @param worktree_path [String] Path for the worktree
+          # @param local_branch_name [String] Local branch name
+          # @param remote_branch [String] Remote branch reference (e.g., "origin/feature")
+          # @param git_root [String] Git repository root
+          # @return [Hash] Result with :success, :worktree_path, :branch, :error
+          def create_worktree_with_tracking(worktree_path, local_branch_name, remote_branch, git_root)
+            require_relative "../atoms/git_command"
+
+            # Ensure parent directory exists
+            parent_dir = File.dirname(worktree_path)
+            FileUtils.mkdir_p(parent_dir) unless File.exist?(parent_dir)
+
+            # Create worktree with tracking: git worktree add <path> -b <local> <remote>
+            result = Atoms::GitCommand.worktree(
+              "add", worktree_path, "-b", local_branch_name, remote_branch,
+              timeout: @timeout
+            )
+
+            if result[:success]
+              {
+                success: true,
+                worktree_path: worktree_path,
+                branch: local_branch_name,
+                tracking: remote_branch,
+                git_root: git_root,
+                error: nil
+              }
+            else
+              error_result("Failed to create worktree: #{result[:error]}")
+            end
+          end
+
+          # Create a worktree for a remote branch
+          #
+          # @param branch_name [String] Full branch name (e.g., "origin/feature/auth")
+          # @param remote_info [Hash] Remote info from detect_remote_branch
+          # @param config [WorktreeConfig] Configuration
+          # @param git_root [String] Git repository root
+          # @return [Hash] Result hash
+          def create_for_remote_branch(branch_name, remote_info, config, git_root)
+            remote = remote_info[:remote]
+            branch = remote_info[:branch]
+
+            # Fetch the remote branch
+            fetch_result = fetch_remote_branch(remote, branch, git_root)
+            return error_result(fetch_result[:error]) unless fetch_result[:success]
+
+            # Generate local branch name (use full branch path to avoid collisions)
+            # For "feature/auth/v1" -> keep as "feature/auth/v1"
+            # For "feature/auth" -> keep as "feature/auth"
+            local_branch_name = branch
+
+            # Generate directory name by replacing slashes with dashes
+            # "feature/auth/v1" -> "feature-auth-v1"
+            directory_name = branch.gsub("/", "-").gsub(/[^a-zA-Z0-9\-_]/, "-")
+
+            # Build worktree path
+            worktree_path = File.join(config.absolute_root_path, directory_name)
+
+            # Validate worktree path
+            validation = validate_worktree_path(worktree_path, git_root)
+            return error_result(validation[:error]) unless validation[:valid]
+
+            # Create worktree with tracking
+            result = create_worktree_with_tracking(
+              worktree_path,
+              local_branch_name,
+              branch_name,
+              git_root
+            )
+            return result unless result[:success]
+
+            # Success
+            {
+              success: true,
+              worktree_path: worktree_path,
+              branch: local_branch_name,
+              tracking: branch_name,
+              directory_name: directory_name,
+              git_root: git_root,
+              error: nil
+            }
+          end
+
+          # Create a worktree for a local branch
+          #
+          # @param branch_name [String] Local branch name
+          # @param config [WorktreeConfig] Configuration
+          # @param git_root [String] Git repository root
+          # @return [Hash] Result hash
+          def create_for_local_branch(branch_name, config, git_root)
+            # Verify branch exists locally
+            require_relative "../atoms/git_command"
+            check_result = Atoms::GitCommand.execute(
+              ["show-ref", "--verify", "--quiet", "refs/heads/#{branch_name}"],
+              timeout: @timeout
+            )
+
+            unless check_result[:success]
+              return error_result("Local branch '#{branch_name}' not found")
+            end
+
+            # Generate directory name
+            directory_name = branch_name.gsub(/[^a-zA-Z0-9\-_]/, "-")
+
+            # Build worktree path
+            worktree_path = File.join(config.absolute_root_path, directory_name)
+
+            # Validate worktree path
+            validation = validate_worktree_path(worktree_path, git_root)
+            return error_result(validation[:error]) unless validation[:valid]
+
+            # Create worktree (no tracking for local branches)
+            result = create_worktree(worktree_path, branch_name, git_root)
+            return result unless result[:success]
+
+            # Success
+            {
+              success: true,
+              worktree_path: worktree_path,
+              branch: branch_name,
+              tracking: nil,
+              directory_name: directory_name,
+              git_root: git_root,
+              error: nil
+            }
+          end
+
+          # Format PR name using template
+          #
+          # @param template [String] Template string with {variables}
+          # @param pr_data [Hash] PR data hash
+          # @return [String] Formatted string
+          #
+          # @example
+          #   format_pr_name("pr-{number}-{slug}", { number: 26, title: "Add Feature" })
+          #   # => "pr-26-add-feature"
+          def format_pr_name(template, pr_data)
+            require_relative "../atoms/slug_generator"
+
+            result = template.dup
+
+            # Replace {number}
+            result.gsub!("{number}", pr_data[:number].to_s)
+
+            # Replace {slug} with slugified title
+            if pr_data[:title]
+              slug = Atoms::SlugGenerator.generate(pr_data[:title])
+              result.gsub!("{slug}", slug)
+            end
+
+            # Replace {title_slug} (alias for slug)
+            if pr_data[:title]
+              slug = Atoms::SlugGenerator.generate(pr_data[:title])
+              result.gsub!("{title_slug}", slug)
+            end
+
+            # Replace {base_branch}
+            result.gsub!("{base_branch}", pr_data[:base_branch].to_s) if pr_data[:base_branch]
+
+            result
           end
         end
       end

--- a/ace-git-worktree/lib/ace/git/worktree/organisms/worktree_manager.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/organisms/worktree_manager.rb
@@ -115,6 +115,143 @@ module Ace
             end
           end
 
+          # Create a worktree for a Pull Request
+          #
+          # @param pr_number [Integer] PR number
+          # @param pr_data [Hash] PR data from PrFetcher
+          # @param options [Hash] Options for creation
+          # @return [Hash] Creation result
+          #
+          # @example
+          #   manager = WorktreeManager.new
+          #   pr_data = { number: 26, title: "Add feature", head_branch: "feature/auth" }
+          #   result = manager.create_pr(26, pr_data)
+          def create_pr(pr_number, pr_data, options = {})
+            begin
+              return error_result("PR number is required") if pr_number.nil?
+              return error_result("PR data is required") if pr_data.nil?
+
+              # Check if worktree already exists for this PR's branch
+              head_branch = pr_data[:head_branch]
+              existing = @worktree_lister.find_by_branch("pr-#{pr_number}") ||
+                        @worktree_lister.find_by_branch(head_branch)
+
+              if existing && !options[:force]
+                return error_result("Worktree already exists at: #{existing.path}")
+              end
+
+              # Handle dry run
+              if options[:dry_run]
+                return dry_run_pr_creation(pr_number, pr_data, options)
+              end
+
+              # Create the worktree
+              result = @worktree_creator.create_for_pr(
+                pr_data,
+                @config,
+                git_root: @project_root
+              )
+
+              if result[:success]
+                result[:pr_number] = pr_number
+                result[:pr_title] = pr_data[:title]
+                result[:message] = "PR worktree created successfully"
+
+                # Execute after-create hooks if configured
+                hooks = @config.after_create_hooks
+                if hooks && hooks.any?
+                  require_relative "../molecules/hook_executor"
+                  hook_executor = Molecules::HookExecutor.new
+                  hook_result = hook_executor.execute_hooks(
+                    hooks,
+                    worktree_path: result[:worktree_path],
+                    project_root: @project_root,
+                    task_data: nil,
+                    pr_data: pr_data
+                  )
+
+                  if hook_result[:success]
+                    result[:hooks_results] = hook_result[:results]
+                  else
+                    result[:warnings] = hook_result[:errors] if hook_result[:errors]&.any?
+                    result[:hooks_results] = hook_result[:results]
+                  end
+                end
+              end
+
+              result
+            rescue StandardError => e
+              error_result("Unexpected error: #{e.message}")
+            end
+          end
+
+          # Create a worktree for a branch (local or remote)
+          #
+          # @param branch_name [String] Branch name (e.g., "feature" or "origin/feature")
+          # @param options [Hash] Options for creation
+          # @return [Hash] Creation result
+          #
+          # @example Remote branch
+          #   result = manager.create_branch("origin/feature/auth")
+          #
+          # @example Local branch
+          #   result = manager.create_branch("my-feature")
+          def create_branch(branch_name, options = {})
+            begin
+              return error_result("Branch name is required") if branch_name.nil? || branch_name.empty?
+
+              # Check if worktree already exists for this branch
+              # Extract just the branch name (remove remote prefix if present)
+              local_branch_name = branch_name.include?("/") ? branch_name.split("/").last : branch_name
+              existing = @worktree_lister.find_by_branch(local_branch_name) ||
+                        @worktree_lister.find_by_branch(branch_name)
+
+              if existing && !options[:force]
+                return error_result("Worktree already exists at: #{existing.path}")
+              end
+
+              # Handle dry run
+              if options[:dry_run]
+                return dry_run_branch_creation(branch_name, options)
+              end
+
+              # Create the worktree
+              result = @worktree_creator.create_for_branch(
+                branch_name,
+                @config,
+                git_root: @project_root
+              )
+
+              if result[:success]
+                result[:message] = "Branch worktree created successfully"
+
+                # Execute after-create hooks if configured
+                hooks = @config.after_create_hooks
+                if hooks && hooks.any?
+                  require_relative "../molecules/hook_executor"
+                  hook_executor = Molecules::HookExecutor.new
+                  hook_result = hook_executor.execute_hooks(
+                    hooks,
+                    worktree_path: result[:worktree_path],
+                    project_root: @project_root,
+                    task_data: nil
+                  )
+
+                  if hook_result[:success]
+                    result[:hooks_results] = hook_result[:results]
+                  else
+                    result[:warnings] = hook_result[:errors] if hook_result[:errors]&.any?
+                    result[:hooks_results] = hook_result[:results]
+                  end
+                end
+              end
+
+              result
+            rescue StandardError => e
+              error_result("Unexpected error: #{e.message}")
+            end
+          end
+
           # List all worktrees
           #
           # @param options [Hash] Listing options
@@ -430,6 +567,67 @@ module Ace
 
           # Create error result
           #
+          # Dry run PR worktree creation
+          #
+          # @param pr_number [Integer] PR number
+          # @param pr_data [Hash] PR data
+          # @param options [Hash] Options
+          # @return [Hash] Dry run result
+          def dry_run_pr_creation(pr_number, pr_data, options)
+            # Simulate what would be created
+            pr_config = @config.pr_config || {}
+            directory_format = pr_config[:directory_format] || "ace-pr-{number}"
+            branch_format = pr_config[:branch_format] || "pr-{number}"
+            remote_name = pr_config[:remote_name] || "origin"
+
+            directory_name = directory_format.gsub("{number}", pr_number.to_s)
+            branch_name = branch_format.gsub("{number}", pr_number.to_s)
+            worktree_path = File.join(@config.absolute_root_path, directory_name)
+            tracking = "#{remote_name}/#{pr_data[:head_branch]}"
+
+            {
+              success: true,
+              pr_number: pr_number,
+              pr_title: pr_data[:title],
+              would_create: {
+                worktree_path: worktree_path,
+                branch: branch_name,
+                tracking: tracking,
+                directory_name: directory_name
+              }
+            }
+          end
+
+          # Dry run branch worktree creation
+          #
+          # @param branch_name [String] Branch name
+          # @param options [Hash] Options
+          # @return [Hash] Dry run result
+          def dry_run_branch_creation(branch_name, options)
+            # Detect remote info
+            remote_info = @worktree_creator.send(:detect_remote_branch, branch_name)
+
+            local_branch = if remote_info
+                            remote_info[:branch].split("/").last
+                          else
+                            branch_name
+                          end
+
+            directory_name = local_branch.gsub(/[^a-zA-Z0-9\-_]/, "-")
+            worktree_path = File.join(@config.absolute_root_path, directory_name)
+            tracking = remote_info ? branch_name : nil
+
+            {
+              success: true,
+              would_create: {
+                worktree_path: worktree_path,
+                branch: local_branch,
+                tracking: tracking,
+                directory_name: directory_name
+              }
+            }
+          end
+
           # @param message [String] Error message
           # @return [Hash] Error result
           def error_result(message)

--- a/ace-git-worktree/lib/ace/git/worktree/version.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/version.rb
@@ -3,7 +3,7 @@
 module Ace
   module Git
     module Worktree
-      VERSION = "0.2.2"
+      VERSION = "0.3.0"
     end
   end
 end

--- a/ace-git-worktree/test/models/worktree_config_test.rb
+++ b/ace-git-worktree/test/models/worktree_config_test.rb
@@ -191,7 +191,7 @@ class WorktreeConfigTest < Minitest::Test
     )
     errors = config.validate
 
-    assert_includes errors, "directory_format must be a non-empty string"
+    assert_includes errors, "task.directory_format must be a non-empty string"
   end
 
   def test_validate_empty_branch_format
@@ -204,7 +204,7 @@ class WorktreeConfigTest < Minitest::Test
     )
     errors = config.validate
 
-    assert_includes errors, "branch_format must be a non-empty string"
+    assert_includes errors, "task.branch_format must be a non-empty string"
   end
 
   def test_validate_missing_template_variables
@@ -328,5 +328,99 @@ class WorktreeConfigTest < Minitest::Test
     config = Ace::Git::Worktree::Models::WorktreeConfig.new(config_data, @project_root)
 
     assert_equal false, config.add_worktree_metadata?
+  end
+
+  def test_validate_invalid_task_template_variables
+    invalid_config = @default_config.dup
+    invalid_config["task"]["branch_format"] = "{id}-{invalid_var}-{slug}"
+
+    config = Ace::Git::Worktree::Models::WorktreeConfig.new(
+      { "git" => { "worktree" => invalid_config } },
+      @project_root
+    )
+    errors = config.validate
+
+    # Should detect invalid_var as invalid
+    assert errors.any? { |error| error.include?("invalid_var") && error.include?("task.branch_format") }
+  end
+
+  def test_validate_invalid_pr_template_variables
+    invalid_config = @default_config.dup
+    invalid_config["pr"]["directory_format"] = "pr-{number}-{invalid_var}"
+
+    config = Ace::Git::Worktree::Models::WorktreeConfig.new(
+      { "git" => { "worktree" => invalid_config } },
+      @project_root
+    )
+    errors = config.validate
+
+    # Should detect invalid_var as invalid
+    assert errors.any? { |error| error.include?("invalid_var") && error.include?("pr.directory_format") }
+  end
+
+  def test_validate_valid_pr_template_variables
+    valid_config = @default_config.dup
+    valid_config["pr"]["directory_format"] = "pr-{number}-{slug}"
+    valid_config["pr"]["branch_format"] = "pr/{number}-{title}"
+
+    config = Ace::Git::Worktree::Models::WorktreeConfig.new(
+      { "git" => { "worktree" => valid_config } },
+      @project_root
+    )
+    errors = config.validate
+
+    # Should not have any errors about invalid variables
+    refute errors.any? { |error| error.include?("pr.directory_format") && error.include?("invalid") }
+    refute errors.any? { |error| error.include?("pr.branch_format") && error.include?("invalid") }
+  end
+
+  def test_validate_empty_pr_directory_format
+    invalid_config = @default_config.dup
+    invalid_config["pr"]["directory_format"] = ""
+
+    config = Ace::Git::Worktree::Models::WorktreeConfig.new(
+      { "git" => { "worktree" => invalid_config } },
+      @project_root
+    )
+    errors = config.validate
+
+    assert_includes errors, "pr.directory_format must be a non-empty string"
+  end
+
+  def test_validate_empty_pr_branch_format
+    invalid_config = @default_config.dup
+    invalid_config["pr"]["branch_format"] = ""
+
+    config = Ace::Git::Worktree::Models::WorktreeConfig.new(
+      { "git" => { "worktree" => invalid_config } },
+      @project_root
+    )
+    errors = config.validate
+
+    assert_includes errors, "pr.branch_format must be a non-empty string"
+  end
+
+  def test_find_invalid_template_variables
+    config = Ace::Git::Worktree::Models::WorktreeConfig.new({}, @project_root)
+
+    # Test with valid variables
+    valid_template = "task-{id}-{slug}"
+    invalid = config.send(:find_invalid_template_variables, valid_template, %w[id slug])
+    assert_empty invalid
+
+    # Test with invalid variables
+    invalid_template = "task-{id}-{invalid}-{slug}"
+    invalid = config.send(:find_invalid_template_variables, invalid_template, %w[id slug])
+    assert_equal ["invalid"], invalid
+
+    # Test with multiple invalid variables
+    multi_invalid = "task-{id}-{bad1}-{bad2}-{slug}"
+    invalid = config.send(:find_invalid_template_variables, multi_invalid, %w[id slug])
+    assert_equal ["bad1", "bad2"], invalid.sort
+
+    # Test with no variables
+    no_vars = "just-text"
+    invalid = config.send(:find_invalid_template_variables, no_vars, %w[id slug])
+    assert_empty invalid
   end
 end

--- a/ace-git-worktree/test/molecules/pr_fetcher_test.rb
+++ b/ace-git-worktree/test/molecules/pr_fetcher_test.rb
@@ -1,0 +1,336 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class PrFetcherTest < Minitest::Test
+  def setup
+    @fetcher = Ace::Git::Worktree::Molecules::PrFetcher.new
+  end
+
+  def test_fetch_with_valid_pr_number
+    pr_json = {
+      "number" => 26,
+      "title" => "Add authentication feature",
+      "headRefName" => "feature/auth",
+      "baseRefName" => "main",
+      "isCrossRepository" => false,
+      "headRepositoryOwner" => { "login" => "user" }
+    }.to_json
+
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { true }
+
+    @fetcher.stub(:gh_available?, true) do
+      Open3.stub(:capture3, [pr_json, "", mock_status]) do
+        pr = @fetcher.fetch(26)
+
+        refute_nil pr
+        assert_equal 26, pr[:number]
+        assert_equal "Add authentication feature", pr[:title]
+        assert_equal "feature/auth", pr[:head_branch]
+        assert_equal "main", pr[:base_branch]
+        assert_equal false, pr[:is_cross_repository]
+        assert_equal "user", pr[:head_repository_owner]
+      end
+    end
+  end
+
+  def test_fetch_with_string_pr_number
+    pr_json = {
+      "number" => 26,
+      "title" => "Test PR",
+      "headRefName" => "test",
+      "baseRefName" => "main"
+    }.to_json
+
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { true }
+
+    @fetcher.stub(:gh_available?, true) do
+      Open3.stub(:capture3, [pr_json, "", mock_status]) do
+        pr = @fetcher.fetch("26")
+        refute_nil pr
+        assert_equal 26, pr[:number]
+      end
+    end
+  end
+
+  def test_fetch_with_fork_pr
+    pr_json = {
+      "number" => 50,
+      "title" => "External contribution",
+      "headRefName" => "fix/bug",
+      "baseRefName" => "main",
+      "isCrossRepository" => true,
+      "headRepositoryOwner" => { "login" => "external-contributor" }
+    }.to_json
+
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { true }
+
+    @fetcher.stub(:gh_available?, true) do
+      Open3.stub(:capture3, [pr_json, "", mock_status]) do
+        pr = @fetcher.fetch(50)
+
+        refute_nil pr
+        assert_equal true, pr[:is_cross_repository]
+        assert_equal "external-contributor", pr[:head_repository_owner]
+      end
+    end
+  end
+
+  def test_fetch_with_invalid_pr_numbers
+    invalid_numbers = [0, -1, "abc", "1.5", "", "  ", nil]
+
+    invalid_numbers.each do |invalid_num|
+      @fetcher.stub(:gh_available?, true) do
+        pr = @fetcher.fetch(invalid_num)
+        assert_nil pr, "Should reject invalid PR number: #{invalid_num.inspect}"
+      end
+    end
+  end
+
+  def test_fetch_with_very_large_pr_number
+    # Should reject unreasonably large PR numbers
+    @fetcher.stub(:gh_available?, true) do
+      pr = @fetcher.fetch(9999999)
+      assert_nil pr
+    end
+  end
+
+  def test_gh_available_when_installed
+    @fetcher.stub(:system, true) do
+      assert @fetcher.gh_available?
+    end
+  end
+
+  def test_gh_available_when_not_installed
+    @fetcher.stub(:system, false) do
+      refute @fetcher.gh_available?
+    end
+  end
+
+  def test_verify_gh_available_succeeds_when_installed
+    @fetcher.stub(:gh_available?, true) do
+      # Should not raise
+      @fetcher.verify_gh_available!
+    end
+  end
+
+  def test_verify_gh_available_raises_when_not_installed
+    @fetcher.stub(:gh_available?, false) do
+      error = assert_raises(Ace::Git::Worktree::Molecules::PrFetcher::GhNotAvailableError) do
+        @fetcher.verify_gh_available!
+      end
+
+      assert_match(/gh CLI is required/, error.message)
+      assert_match(/brew install gh/, error.message)
+    end
+  end
+
+  def test_fetch_raises_when_gh_not_available
+    @fetcher.stub(:gh_available?, false) do
+      error = assert_raises(Ace::Git::Worktree::Molecules::PrFetcher::GhNotAvailableError) do
+        @fetcher.fetch(26)
+      end
+
+      assert_match(/gh CLI is required/, error.message)
+    end
+  end
+
+  def test_fetch_raises_when_pr_not_found
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { false }
+
+    stderr_output = "could not resolve to a PullRequest"
+
+    @fetcher.stub(:gh_available?, true) do
+      @fetcher.stub(:get_repository_name, "test-org/test-repo") do
+        Open3.stub(:capture3, ["", stderr_output, mock_status]) do
+          error = assert_raises(Ace::Git::Worktree::Molecules::PrFetcher::PrNotFoundError) do
+            @fetcher.fetch(999)
+          end
+
+          assert_match(/PR #999 not found in test-org\/test-repo/, error.message)
+        end
+      end
+    end
+  end
+
+  def test_fetch_raises_when_not_authenticated
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { false }
+
+    stderr_output = "authentication required"
+
+    @fetcher.stub(:gh_available?, true) do
+      Open3.stub(:capture3, ["", stderr_output, mock_status]) do
+        error = assert_raises(Ace::Git::Worktree::Molecules::PrFetcher::NetworkError) do
+          @fetcher.fetch(26)
+        end
+
+        assert_match(/not authenticated/, error.message)
+        assert_match(/gh auth login/, error.message)
+      end
+    end
+  end
+
+  def test_fetch_raises_on_network_error
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { false }
+
+    stderr_output = "network connection failed"
+
+    @fetcher.stub(:gh_available?, true) do
+      Open3.stub(:capture3, ["", stderr_output, mock_status]) do
+        error = assert_raises(Ace::Git::Worktree::Molecules::PrFetcher::NetworkError) do
+          @fetcher.fetch(26)
+        end
+
+        assert_match(/Network error/, error.message)
+      end
+    end
+  end
+
+  def test_fetch_raises_on_invalid_json
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { true }
+
+    invalid_json = "not valid json{["
+
+    @fetcher.stub(:gh_available?, true) do
+      Open3.stub(:capture3, [invalid_json, "", mock_status]) do
+        error = assert_raises(Ace::Git::Worktree::Molecules::PrFetcher::NetworkError) do
+          @fetcher.fetch(26)
+        end
+
+        assert_match(/Failed to parse/, error.message)
+      end
+    end
+  end
+
+  def test_fetch_raises_on_missing_required_fields
+    # JSON missing required fields
+    incomplete_json = {
+      "number" => 26,
+      "title" => "Test"
+      # Missing headRefName and baseRefName
+    }.to_json
+
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { true }
+
+    @fetcher.stub(:gh_available?, true) do
+      Open3.stub(:capture3, [incomplete_json, "", mock_status]) do
+        error = assert_raises(Ace::Git::Worktree::Molecules::PrFetcher::NetworkError) do
+          @fetcher.fetch(26)
+        end
+
+        assert_match(/Invalid PR data/, error.message)
+        assert_match(/missing fields/, error.message)
+      end
+    end
+  end
+
+  def test_gh_not_available_message
+    message = @fetcher.gh_not_available_message
+
+    assert_match(/gh CLI is required/, message)
+    assert_match(/brew install gh/, message)
+    assert_match(/gh auth login/, message)
+  end
+
+  def test_fetch_with_timeout
+    # Test that timeout is respected
+    @fetcher.stub(:gh_available?, true) do
+      @fetcher.stub(:execute_with_timeout, proc { raise Timeout::Error }) do
+        error = assert_raises(Ace::Git::Worktree::Molecules::PrFetcher::NetworkError) do
+          @fetcher.fetch(26)
+        end
+
+        assert_match(/timed out/, error.message)
+      end
+    end
+  end
+
+  def test_get_repository_name_success
+    # Test successful repository name retrieval
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { true }
+
+    Open3.stub(:capture3, ["test-owner/test-repo\n", "", mock_status]) do
+      repo_name = @fetcher.send(:get_repository_name)
+      assert_equal "test-owner/test-repo", repo_name
+    end
+  end
+
+  def test_get_repository_name_failure
+    # Test when repository name cannot be determined
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { false }
+
+    Open3.stub(:capture3, ["", "error", mock_status]) do
+      repo_name = @fetcher.send(:get_repository_name)
+      assert_nil repo_name
+    end
+  end
+
+  def test_get_repository_name_caching
+    # Test that repository name is cached
+    call_count = 0
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { true }
+
+    Open3.stub(:capture3, proc {
+      call_count += 1
+      ["test-repo\n", "", mock_status]
+    }) do
+      # First call should fetch
+      @fetcher.send(:get_repository_name)
+      # Second call should use cache
+      @fetcher.send(:get_repository_name)
+
+      assert_equal 1, call_count, "Repository name should be cached after first call"
+    end
+  end
+
+  def test_error_message_with_repository_context
+    # Test that error messages include repository context
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { false }
+
+    stderr_output = "could not resolve to a PullRequest"
+
+    @fetcher.stub(:gh_available?, true) do
+      @fetcher.stub(:get_repository_name, "owner/repo") do
+        Open3.stub(:capture3, ["", stderr_output, mock_status]) do
+          error = assert_raises(Ace::Git::Worktree::Molecules::PrFetcher::PrNotFoundError) do
+            @fetcher.fetch(123)
+          end
+
+          assert_match(/in owner\/repo/, error.message)
+        end
+      end
+    end
+  end
+
+  def test_error_message_without_repository_context
+    # Test fallback when repository name is unavailable
+    mock_status = Object.new
+    mock_status.define_singleton_method(:success?) { false }
+
+    stderr_output = "could not resolve to a PullRequest"
+
+    @fetcher.stub(:gh_available?, true) do
+      @fetcher.stub(:get_repository_name, nil) do
+        Open3.stub(:capture3, ["", stderr_output, mock_status]) do
+          error = assert_raises(Ace::Git::Worktree::Molecules::PrFetcher::PrNotFoundError) do
+            @fetcher.fetch(123)
+          end
+
+          assert_match(/in this repository/, error.message)
+        end
+      end
+    end
+  end
+end

--- a/ace-git-worktree/test/molecules/worktree_creator_test.rb
+++ b/ace-git-worktree/test/molecules/worktree_creator_test.rb
@@ -305,11 +305,325 @@ class WorktreeCreatorTest < Minitest::Test
     end
   end
 
+  # Tests for PR worktree creation
+  def test_create_for_pr_success
+    pr_data = {
+      number: 26,
+      title: "Add authentication feature",
+      head_branch: "feature/auth",
+      base_branch: "main"
+    }
+
+    config = mock_pr_config(@temp_dir)
+
+    # Mock git root detection
+    @creator.stub(:detect_git_root, @temp_dir) do
+      # Mock path validation
+      @creator.stub(:validate_worktree_path, { valid: true, error: nil }) do
+        # Mock fetch
+        @creator.stub(:fetch_remote_branch, { success: true, error: nil }) do
+          # Mock worktree creation
+          @creator.stub(:create_worktree_with_tracking, {
+            success: true,
+            worktree_path: File.join(@temp_dir, "ace-pr-26"),
+            branch: "pr-26",
+            tracking: "origin/feature/auth",
+            git_root: @temp_dir,
+            error: nil
+          }) do
+            result = @creator.create_for_pr(pr_data, config)
+
+            assert result[:success]
+            assert_equal "pr-26", result[:branch]
+            assert_equal "origin/feature/auth", result[:tracking]
+            assert_equal 26, result[:pr_number]
+            assert_equal "Add authentication feature", result[:pr_title]
+          end
+        end
+      end
+    end
+  end
+
+  def test_create_for_pr_without_pr_data
+    config = mock_pr_config(@temp_dir)
+    result = @creator.create_for_pr(nil, config)
+
+    refute result[:success]
+    assert_match /PR data is required/, result[:error]
+  end
+
+  def test_create_for_pr_without_config
+    pr_data = { number: 26, title: "Test", head_branch: "test", base_branch: "main" }
+    result = @creator.create_for_pr(pr_data, nil)
+
+    refute result[:success]
+    assert_match /Configuration is required/, result[:error]
+  end
+
+  def test_create_for_pr_fetch_failure
+    pr_data = {
+      number: 26,
+      title: "Test PR",
+      head_branch: "feature/test",
+      base_branch: "main"
+    }
+
+    config = mock_pr_config(@temp_dir)
+
+    @creator.stub(:detect_git_root, @temp_dir) do
+      @creator.stub(:validate_worktree_path, { valid: true, error: nil }) do
+        # Mock fetch failure
+        @creator.stub(:fetch_remote_branch, { success: false, error: "Network error" }) do
+          result = @creator.create_for_pr(pr_data, config)
+
+          refute result[:success]
+          assert_match /Network error/, result[:error]
+        end
+      end
+    end
+  end
+
+  # Tests for branch worktree creation
+  def test_create_for_branch_remote_success
+    config = mock_pr_config(@temp_dir)
+
+    @creator.stub(:detect_git_root, @temp_dir) do
+      # Mock remote branch detection
+      @creator.stub(:detect_remote_branch, { remote: "origin", branch: "feature/auth" }) do
+        # Mock create_for_remote_branch
+        @creator.stub(:create_for_remote_branch, {
+          success: true,
+          worktree_path: File.join(@temp_dir, "feature-auth"),
+          branch: "feature/auth",
+          tracking: "origin/feature/auth",
+          directory_name: "feature-auth",
+          git_root: @temp_dir,
+          error: nil
+        }) do
+          result = @creator.create_for_branch("origin/feature/auth", config)
+
+          assert result[:success]
+          assert_equal "feature/auth", result[:branch]
+          assert_equal "origin/feature/auth", result[:tracking]
+        end
+      end
+    end
+  end
+
+  def test_create_for_branch_local_success
+    config = mock_pr_config(@temp_dir)
+
+    @creator.stub(:detect_git_root, @temp_dir) do
+      # Mock local branch (no remote prefix)
+      @creator.stub(:detect_remote_branch, nil) do
+        # Mock create_for_local_branch
+        @creator.stub(:create_for_local_branch, {
+          success: true,
+          worktree_path: File.join(@temp_dir, "feature"),
+          branch: "feature",
+          tracking: nil,
+          directory_name: "feature",
+          git_root: @temp_dir,
+          error: nil
+        }) do
+          result = @creator.create_for_branch("feature", config)
+
+          assert result[:success]
+          assert_equal "feature", result[:branch]
+          assert_nil result[:tracking]
+        end
+      end
+    end
+  end
+
+  def test_create_for_branch_without_branch_name
+    config = mock_pr_config(@temp_dir)
+    result = @creator.create_for_branch(nil, config)
+
+    refute result[:success]
+    assert_match /Branch name is required/, result[:error]
+  end
+
+  def test_create_for_branch_empty_branch_name
+    config = mock_pr_config(@temp_dir)
+    result = @creator.create_for_branch("", config)
+
+    refute result[:success]
+    assert_match /Branch name is required/, result[:error]
+  end
+
+  def test_create_for_branch_without_config
+    result = @creator.create_for_branch("feature", nil)
+
+    refute result[:success]
+    assert_match /Configuration is required/, result[:error]
+  end
+
+  def test_detect_remote_branch_with_remote
+    remote_branches = {
+      "origin/feature" => { remote: "origin", branch: "feature" },
+      "upstream/main" => { remote: "upstream", branch: "main" },
+      "origin/feature/auth" => { remote: "origin", branch: "feature/auth" },
+      "fork/bugfix/123" => { remote: "fork", branch: "bugfix/123" }
+    }
+
+    remote_branches.each do |input, expected|
+      result = @creator.send(:detect_remote_branch, input)
+      assert_equal expected, result, "Failed for #{input}"
+    end
+  end
+
+  def test_detect_remote_branch_without_remote
+    local_branches = ["main", "feature", "bugfix-123", "release_v1.0"]
+
+    local_branches.each do |branch|
+      result = @creator.send(:detect_remote_branch, branch)
+      assert_nil result, "Should return nil for local branch: #{branch}"
+    end
+  end
+
+  def test_detect_remote_branch_invalid_format
+    invalid = ["origin/", "/feature", "/", "origin//feature"]
+
+    invalid.each do |input|
+      result = @creator.send(:detect_remote_branch, input)
+      assert_nil result, "Should return nil for invalid format: #{input}"
+    end
+  end
+
+  def test_format_pr_name_with_number
+    pr_data = { number: 26, title: "Add Feature" }
+    template = "pr-{number}"
+
+    result = @creator.send(:format_pr_name, template, pr_data)
+    assert_equal "pr-26", result
+  end
+
+  def test_format_pr_name_with_slug
+    pr_data = { number: 26, title: "Add Authentication Feature" }
+    template = "pr-{number}-{slug}"
+
+    # Mock slug generator
+    Ace::Git::Worktree::Atoms::SlugGenerator.stub(:generate, "add-authentication-feature") do
+      result = @creator.send(:format_pr_name, template, pr_data)
+      assert_equal "pr-26-add-authentication-feature", result
+    end
+  end
+
+  def test_format_pr_name_with_multiple_variables
+    pr_data = { number: 26, title: "Test Feature", base_branch: "main" }
+    template = "{base_branch}-pr-{number}"
+
+    result = @creator.send(:format_pr_name, template, pr_data)
+    assert_equal "main-pr-26", result
+  end
+
   private
 
   def mock_config(root_path)
     config = Object.new
     config.define_singleton_method(:absolute_root_path) { root_path }
     config
+  end
+
+  def mock_pr_config(root_path)
+    config = mock_config(root_path)
+    config.define_singleton_method(:pr_config) do
+      {
+        remote_name: "origin",
+        directory_format: "ace-pr-{number}",
+        branch_format: "pr-{number}"
+      }
+    end
+    config
+  end
+
+  def test_validate_remote_exists_with_valid_remote
+    Dir.mktmpdir do |root_path|
+      creator = Ace::Git::Worktree::Molecules::WorktreeCreator.new
+
+      # Mock git remote command to return "origin"
+      Ace::Git::Worktree::Atoms::GitCommand.stub(:execute, { success: true, output: "origin\nupstream\n" }) do
+        result = creator.send(:validate_remote_exists, "origin", root_path)
+
+        assert result[:exists]
+        assert_equal ["origin", "upstream"], result[:remotes]
+      end
+    end
+  end
+
+  def test_validate_remote_exists_with_invalid_remote
+    Dir.mktmpdir do |root_path|
+      creator = Ace::Git::Worktree::Molecules::WorktreeCreator.new
+
+      # Mock git remote command to return only "origin"
+      Ace::Git::Worktree::Atoms::GitCommand.stub(:execute, { success: true, output: "origin\n" }) do
+        result = creator.send(:validate_remote_exists, "invalid", root_path)
+
+        refute result[:exists]
+        assert_equal ["origin"], result[:remotes]
+      end
+    end
+  end
+
+  def test_validate_remote_exists_with_no_remotes
+    Dir.mktmpdir do |root_path|
+      creator = Ace::Git::Worktree::Molecules::WorktreeCreator.new
+
+      # Mock git remote command to return empty
+      Ace::Git::Worktree::Atoms::GitCommand.stub(:execute, { success: true, output: "" }) do
+        result = creator.send(:validate_remote_exists, "origin", root_path)
+
+        refute result[:exists]
+        assert_equal [""], result[:remotes]
+      end
+    end
+  end
+
+  def test_fetch_remote_branch_validates_remote
+    Dir.mktmpdir do |root_path|
+      creator = Ace::Git::Worktree::Molecules::WorktreeCreator.new
+
+      # Mock validation to return invalid remote
+      creator.stub(:validate_remote_exists, { exists: false, remotes: ["origin", "upstream"] }) do
+        result = creator.send(:fetch_remote_branch, "invalid", "main", root_path)
+
+        refute result[:success]
+        assert_match(/Remote 'invalid' not found/, result[:error])
+        assert_match(/origin, upstream/, result[:error])
+      end
+    end
+  end
+
+  def test_fetch_remote_branch_with_no_remotes_configured
+    Dir.mktmpdir do |root_path|
+      creator = Ace::Git::Worktree::Molecules::WorktreeCreator.new
+
+      # Mock validation to return no remotes
+      creator.stub(:validate_remote_exists, { exists: false, remotes: [] }) do
+        result = creator.send(:fetch_remote_branch, "origin", "main", root_path)
+
+        refute result[:success]
+        assert_match(/Remote 'origin' not found/, result[:error])
+        assert_match(/no remotes configured/, result[:error])
+      end
+    end
+  end
+
+  def test_fetch_remote_branch_proceeds_with_valid_remote
+    Dir.mktmpdir do |root_path|
+      creator = Ace::Git::Worktree::Molecules::WorktreeCreator.new
+
+      # Mock validation to return valid remote
+      creator.stub(:validate_remote_exists, { exists: true, remotes: ["origin"] }) do
+        # Mock fetch command to succeed
+        Ace::Git::Worktree::Atoms::GitCommand.stub(:execute, { success: true, output: "" }) do
+          result = creator.send(:fetch_remote_branch, "origin", "main", root_path)
+
+          assert result[:success]
+          assert_nil result[:error]
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit introduces functionality to create git worktrees directly from GitHub pull requests and specified branches.

The new `--pr <number>` flag allows developers to create a worktree for a given pull request, automatically fetching its metadata and branch information using the GitHub CLI (`gh`). This enhances the workflow by enabling quick access to feature branches for review or development.

Additionally, the `-b <branch>` flag is enhanced to support creation from both local and remote branches, with automatic fetching of remote branches if they do not exist locally.

Key features include:
- **PR Worktree Creation**: Uses `gh pr view` to fetch PR details and automatically configures remote tracking.
- **Branch Worktree Creation**: Supports local and remote branches, with automatic fetching.
- **GitHub CLI Integration**: `gh` CLI is a hard requirement for PR functionality, with early validation and clear installation instructions.
- **Fork PR Detection**: Warns users when a PR originates from a fork or an external repository.
- **Error Handling**: Provides specific error messages for common issues like missing `gh` CLI, invalid PR numbers, or network problems.
- **Configuration**: Supports configurable directory and branch naming conventions for PR worktrees.

This feature aims to streamline the development process by reducing the manual steps involved in setting up work environments for pull requests and specific branches.

Implementation Details:
- Added PrFetcher molecule for GitHub API integration via gh CLI
- Extended WorktreeCreator with create_for_pr() and create_for_branch() methods
- Updated WorktreeConfig model with PR and branch configuration support
- Integrated CLI options in CreateCommand (--pr, --pull-request, -b, --branch)
- Extended WorktreeManager with create_pr() and create_branch() orchestration
- Added comprehensive test coverage for PrFetcher

Task: v.0.9.0+task.105