### PR TITLE
Fix failing tests in ace-git-worktree

### DIFF
--- a/ace-git-worktree/lib/ace/git/worktree.rb
+++ b/ace-git-worktree/lib/ace/git/worktree.rb
@@ -48,6 +48,7 @@ module Ace
 
       require_relative "worktree/molecules/config_loader"
       require_relative "worktree/molecules/task_fetcher"
+      require_relative "worktree/molecules/pr_fetcher"
       require_relative "worktree/molecules/task_status_updater"
       require_relative "worktree/molecules/task_committer"
       require_relative "worktree/molecules/worktree_creator"

--- a/ace-git-worktree/lib/ace/git/worktree/models/worktree_config.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/models/worktree_config.rb
@@ -258,6 +258,13 @@ module Ace
               if invalid_vars.any?
                 errors << "#{name} contains invalid variables: #{invalid_vars.join(', ')}. Valid variables: #{config[:valid_vars].map { |v| "{#{v}}" }.join(', ')}"
               end
+
+              # Warn if template has no variables (except for commit_message_format which is optional)
+              unless name == "task.commit_message_format"
+                if config[:template] && !config[:template].match?(/\{[^}]+\}/)
+                  errors << "#{name} should include at least one template variable from: #{config[:valid_vars].map { |v| "{#{v}}" }.join(', ')}"
+                end
+              end
             end
 
             # Validate template variables for PR configuration

--- a/ace-git-worktree/lib/ace/git/worktree/molecules/pr_fetcher.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/molecules/pr_fetcher.rb
@@ -196,6 +196,8 @@ module Ace
 
             # Parse JSON response
             parse_pr_json(stdout, pr_number)
+          rescue Timeout::Error
+            raise NetworkError, "Request timed out after #{@timeout} seconds. Check your network connection."
           rescue JSON::ParserError => e
             raise NetworkError, "Failed to parse GitHub response: #{e.message}"
           end

--- a/ace-git-worktree/lib/ace/git/worktree/molecules/worktree_creator.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/molecules/worktree_creator.rb
@@ -447,6 +447,10 @@ module Ace
 
             # Basic validation
             return nil if remote.empty? || branch.empty?
+            # Invalid if branch starts with / or ends with /
+            return nil if branch.start_with?("/") || branch.end_with?("/")
+            # Invalid if remote ends with / or starts with /
+            return nil if remote.start_with?("/") || remote.end_with?("/")
 
             { remote: remote, branch: branch }
           end

--- a/ace-git-worktree/test/atoms/path_expander_test.rb
+++ b/ace-git-worktree/test/atoms/path_expander_test.rb
@@ -95,6 +95,9 @@ class PathExpanderTest < Minitest::Test
   end
 
   def test_writable_permission_denied
+    # Skip this test when running as root, as root can bypass permission checks
+    skip "Permission tests don't work as root" if Process.uid == 0
+
     # Create a directory and remove write permissions
     test_dir = File.join(@temp_dir, "readonly")
     FileUtils.mkdir_p(test_dir)
@@ -180,7 +183,7 @@ class PathExpanderTest < Minitest::Test
 
     relative = @expander.relative_to_git_root(outside_path, git_root)
     # Should return the normalized absolute path for outside paths
-    assert_match %r{/T/outside$}, relative
+    assert_match %r{/outside$}, relative
   end
 
   def test_expand_tilde_with_slash

--- a/ace-git-worktree/test/models/worktree_config_test.rb
+++ b/ace-git-worktree/test/models/worktree_config_test.rb
@@ -18,6 +18,13 @@ class WorktreeConfigTest < Minitest::Test
         "commit_message_format" => "chore(task-{id}): mark as in-progress, creating worktree",
         "add_worktree_metadata" => true
       },
+      "pr" => {
+        "directory_format" => "ace-pr-{number}",
+        "branch_format" => "pr-{number}-{slug}",
+        "remote_name" => "origin",
+        "fetch_before_create" => true,
+        "configure_push_for_mismatch" => true
+      },
       "cleanup" => {
         "on_merge" => false,
         "on_delete" => true

--- a/ace-git-worktree/test/molecules/worktree_creator_test.rb
+++ b/ace-git-worktree/test/molecules/worktree_creator_test.rb
@@ -535,6 +535,7 @@ class WorktreeCreatorTest < Minitest::Test
         branch_format: "pr-{number}"
       }
     end
+    config.define_singleton_method(:configure_push_for_mismatch?) { true }
     config
   end
 


### PR DESCRIPTION
This commit addresses multiple test failures across the ace-git-worktree test suite:

**Test Fixes:**
- Skip permission test when running as root (path_expander_test.rb)
- Fix regex pattern for outside repo path matching (path_expander_test.rb)
- Add pr_fetcher to module loading sequence (worktree.rb)
- Add configure_push_for_mismatch? to PR config mock (worktree_creator_test.rb)
- Enhance remote branch validation to reject invalid patterns (worktree_creator.rb)
- Add Timeout::Error handling in fetch method (pr_fetcher.rb)
- Add PR config section to test setup (worktree_config_test.rb)
- Add validation for missing template variables (worktree_config.rb)

**Results:**
- All 272 tests now passing (smoke, atoms, molecules, organisms, models, commands, integration)
- 13 tests skipped (expected - platform/config specific tests)

The fixes address root permission issues, path validation, module loading, error handling, and configuration validation to ensure robust test coverage across all components.