### PR TITLE
fix(ace-taskflow): improve idea create output to show full file path

### DIFF
--- a/.ace-taskflow/v.0.9.0/tasks/done/109-taskflow-fix/109-improve-idea-create-output-show-full-file-path.s.md
+++ b/.ace-taskflow/v.0.9.0/tasks/done/109-taskflow-fix/109-improve-idea-create-output-show-full-file-path.s.md
@@ -1,6 +1,6 @@
 ---
 id: v.0.9.0+task.109
-status: pending
+status: done
 priority: low
 estimate: 30min
 dependencies: []
@@ -32,7 +32,7 @@ Idea captured: .ace-taskflow/v.0.9.0/ideas/20251113-105651-taskflow-test/test-cr
 ### Success Criteria
 - [x] **Folder Creation**: Ideas are already being created in proper folder structure ✅ (ALREADY WORKING)
 - [x] **File Creation**: .s.md files are created inside folders ✅ (ALREADY WORKING)
-- [ ] **Output Message**: Show full path to the .s.md file, not just the folder
+- [x] **Output Message**: Show full path to the .s.md file, not just the folder ✅ (COMPLETED)
 
 ## Objective
 
@@ -63,33 +63,26 @@ The `IdeaWriter.write()` method (line 118 in `idea_writer.rb`) returns the folde
 ### Planning Steps
 * [x] Identify that folder-based idea creation is already working ✅
 * [x] Confirm the only issue is output message ✅
-* [ ] Determine best approach to get file path
+* [x] Determine best approach to get file path ✅ (Chose Option A)
 
 ### Execution Steps
 
-- [ ] Update output to show full file path
-  **Option A**: Modify `IdeaWriter.write()` to return file path instead of folder path
-  ```ruby
-  # In idea_writer.rb line 118, instead of:
-  path  # Returns folder
-  # Return:
-  file_path  # Returns full path to .s.md file
-  ```
+- [x] Update output to show full file path ✅
+  **Implemented Option A**: Modified `IdeaWriter.write()` to return file path instead of folder path
 
-  **Option B**: Update `IdeaCommand.create_idea()` to construct full path
-  ```ruby
-  # In idea_command.rb after line 197:
-  # Get the actual file that was created
-  idea_files = Dir.glob(File.join(path, "*.s.md"))
-  file_path = idea_files.first || path
-  relative_path = Atoms::PathFormatter.format_relative_path(file_path, root_path)
-  ```
+  Changes made:
+  - Modified `ace-taskflow/lib/ace/taskflow/organisms/idea_writer.rb` line 118 to return `idea_file` instead of `path`
+  - Updated all test files to expect file paths instead of folder paths:
+    - `ace-taskflow/test/organisms/idea_writer_test.rb`
+    - `ace-taskflow/test/integration/idea_writer_integration_test.rb`
+    - `ace-taskflow/test/organisms/idea_writer_clipboard_test.rb`
 
-- [ ] Test the output shows full file path
+- [x] Test the output shows full file path ✅
   > TEST: Output shows file path
   > Type: Manual Test
   > Assert: Running `ace-taskflow idea create` shows path to .s.md file
-  > Command: ace-taskflow idea create -gc "test" and verify output
+  > Command: ace-taskflow idea create "test" and verify output
+  > Result: PASSED - Output shows `.ace-taskflow/v.0.9.0/ideas/20251115-085126-test-fix/final-test-of-task-109-output-fix.s.md`
 
 ## File Modifications
 

--- a/ace-taskflow/CHANGELOG.md
+++ b/ace-taskflow/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Idea Create Output Enhancement**: Improved `ace-taskflow idea create` output to display full file path instead of just folder path
+  - Modified `IdeaWriter#write` to return complete path to created `.s.md` file
+  - Updated output message to show exact file created (e.g., `.ace-taskflow/v.0.9.0/ideas/20251115-085126-test/test.s.md`)
+  - Makes it immediately clear which file was created and easier to open in editors
+  - Added YARD documentation for `IdeaWriter#write` method with parameter and return value specifications
+  - Added regression test to ensure file path (not directory) is returned
+
 ## [0.18.4] - 2025-11-04
 
 ### Fixed

--- a/ace-taskflow/lib/ace/taskflow/organisms/idea_writer.rb
+++ b/ace-taskflow/lib/ace/taskflow/organisms/idea_writer.rb
@@ -19,6 +19,18 @@ module Ace
           @debug = ENV["DEBUG"] == "true"
         end
 
+        # Writes an idea to the filesystem with optional enhancements
+        #
+        # @param content [String] the idea content to write
+        # @param options [Hash] options for idea creation
+        # @option options [Boolean] :git_commit auto-commit the idea file
+        # @option options [Boolean] :llm_enhance enhance content with LLM
+        # @option options [Boolean] :clipboard merge clipboard content
+        # @option options [String] :title custom title for the idea
+        # @option options [String] :location target location (active/backlog/release)
+        # @option options [String] :subdirectory subdirectory within ideas (maybe/anyday)
+        # @return [String] full path to the created idea file (*.s.md)
+        # @raise [IdeaWriterError] if no content is provided
         def write(content, options = {})
           # Merge options with config defaults
           options = merge_options_with_config(options)
@@ -115,7 +127,7 @@ module Ace
             commit_idea(path, metadata)
           end
 
-          path
+          idea_file
         end
 
         private

--- a/ace-taskflow/test/integration/idea_writer_integration_test.rb
+++ b/ace-taskflow/test/integration/idea_writer_integration_test.rb
@@ -35,20 +35,17 @@ class IdeaWriterIntegrationTest < AceTaskflowTestCase
         # Execute write
         path = writer.write(content, metadata)
 
+        # Verify it returns the file path
+        assert File.exist?(path), "Idea file should exist"
+        assert_match(/integration-test\/complete-workflow\.s\.md$/, path, "Should return full file path")
+
         # Verify directory was created
-        assert Dir.exist?(path), "Idea directory should exist"
-        assert_match(/integration-test$/, path, "Directory should contain folder slug")
+        folder_path = File.dirname(path)
+        assert Dir.exist?(folder_path), "Idea directory should exist"
+        assert_match(/integration-test$/, folder_path, "Directory should contain folder slug")
 
-        # Verify idea file was created
-        idea_files = Dir.glob(File.join(path, "*.s.md"))
-        assert_equal 1, idea_files.length, "Should have exactly one idea file"
-
-        idea_file = idea_files.first
-        assert File.exist?(idea_file), "Idea file should exist"
-        assert_match(/complete-workflow\.s\.md$/, idea_file, "File should use file slug")
-
-        # Verify file content
-        file_content = File.read(idea_file)
+        # Verify file content (path is now the file path)
+        file_content = File.read(path)
         assert_includes file_content, "# Integration Test", "Should include title"
         assert_includes file_content, content, "Should include original content"
         assert_includes file_content, "2025-01-01 12:00:00", "Should include timestamp"
@@ -90,15 +87,17 @@ class IdeaWriterIntegrationTest < AceTaskflowTestCase
       mock_llm_query(response_text: mock_slug_resp) do
         path = writer.write(enhanced_content)
 
+        # Verify file path is returned
+        assert File.exist?(path), "Idea file should exist"
+        assert_match(/llm-enhanced\/test-idea\.s\.md$/, path, "Should return full file path")
+
         # Verify directory structure
-        assert Dir.exist?(path)
-        assert_match(/llm-enhanced$/, path)
+        folder_path = File.dirname(path)
+        assert Dir.exist?(folder_path)
+        assert_match(/llm-enhanced$/, folder_path)
 
         # Verify content was written as-is (no template applied)
-        idea_files = Dir.glob(File.join(path, "*.s.md"))
-        assert idea_files.any?, "Should create idea file"
-
-        file_content = File.read(idea_files.first)
+        file_content = File.read(path)
         # Enhanced content should be preserved (starts with frontmatter)
         assert file_content.start_with?("---\n"), "Should preserve frontmatter"
         assert_includes file_content, "# LLM Enhanced Idea"

--- a/ace-taskflow/test/organisms/idea_writer_clipboard_test.rb
+++ b/ace-taskflow/test/organisms/idea_writer_clipboard_test.rb
@@ -57,20 +57,20 @@ class IdeaWriterClipboardTest < AceTaskflowTestCase
 
       path = @writer.write("review these files", clipboard: true)
 
-      # Should create directory (not flat file)
-      assert Dir.exist?(path), "Expected directory to be created"
-      refute File.file?(path), "Should not be a flat file"
+      # Should return file path (not directory)
+      assert File.exist?(path), "Expected file to be created"
+      assert File.file?(path), "Should be a file"
 
-      # Should have idea.md inside
-      idea_file = File.join(path, "idea.md")
-      assert File.exist?(idea_file), "Expected idea.md to exist"
+      # Get directory from file path
+      folder_path = File.dirname(path)
+      assert Dir.exist?(folder_path), "Expected directory to be created"
 
-      # Should have attached files
-      assert File.exist?(File.join(path, "test1.rb"))
-      assert File.exist?(File.join(path, "test2.rb"))
+      # Should have attached files in the directory
+      assert File.exist?(File.join(folder_path, "test1.rb"))
+      assert File.exist?(File.join(folder_path, "test2.rb"))
 
-      # Content should reference files
-      content = File.read(idea_file)
+      # Content should reference files (path is now the idea file)
+      content = File.read(path)
       assert_match(/test1\.rb/, content)
       assert_match(/test2\.rb/, content)
     end

--- a/ace-taskflow/test/organisms/idea_writer_test.rb
+++ b/ace-taskflow/test/organisms/idea_writer_test.rb
@@ -28,11 +28,12 @@ class IdeaWriterUnitTest < AceTaskflowTestCase
         content = "This is a test idea"
         path = @writer.write(content)
 
-        # Verify path format: /test/ideas/YYYYMMDD-HHMMSS-test-idea
-        assert_match(%r{^/test/ideas/\d{8}-\d{6}-test-idea$}, path)
+        # Verify path format: /test/ideas/YYYYMMDD-HHMMSS-test-idea/test-content.s.md
+        assert_match(%r{^/test/ideas/\d{8}-\d{6}-test-idea/test-content\.s\.md$}, path)
 
-        # Verify directory was created
-        assert @mkdir_calls.include?(path), "Should create idea directory"
+        # Verify directory was created (extract folder from file path)
+        folder_path = File.dirname(path)
+        assert @mkdir_calls.include?(folder_path), "Should create idea directory"
 
         # Verify file was written
         assert @write_calls.any? { |call| call[:path].include?("test-content.s.md") }
@@ -50,8 +51,8 @@ class IdeaWriterUnitTest < AceTaskflowTestCase
       mock_llm_query(response_text: mock_slug_resp) do
         path = writer.write("Test content")
 
-        # Verify path uses custom directory
-        assert_match(%r{^/custom/ideas/\d{8}-\d{6}-custom-dir$}, path)
+        # Verify path uses custom directory and includes file
+        assert_match(%r{^/custom/ideas/\d{8}-\d{6}-custom-dir/test-idea\.s\.md$}, path)
       end
     end
   end
@@ -65,7 +66,8 @@ class IdeaWriterUnitTest < AceTaskflowTestCase
 
         # Verify mkdir_p was called (creates parent directories)
         assert @mkdir_calls.any?, "Should call mkdir_p"
-        assert_match(/nested-idea$/, path)
+        # Path should be a file, folder name should contain nested-idea
+        assert_match(/nested-idea\/test-content\.s\.md$/, path)
       end
     end
   end
@@ -103,8 +105,8 @@ class IdeaWriterUnitTest < AceTaskflowTestCase
         content = "This is a long idea that should be truncated for title"
         path = @writer.write(content)
 
-        # Verify path contains folder slug
-        assert_match(/long-idea$/, path)
+        # Verify path contains folder slug and file
+        assert_match(/long-idea\/truncated-title\.s\.md$/, path)
 
         # Verify file slug is used in filename
         write_call = @write_calls.first
@@ -143,6 +145,29 @@ class IdeaWriterUnitTest < AceTaskflowTestCase
         write_call = @write_calls.first
         # Content should be returned as-is (no template applied)
         assert_equal enhanced_content, write_call[:content]
+      end
+    end
+  end
+
+  def test_write_returns_file_path_not_directory
+    mock_slug_resp = mock_slug_response(folder_slug: "regression-test", file_slug: "file-path-return")
+
+    mock_filesystem do
+      mock_llm_query(response_text: mock_slug_resp) do
+        path = @writer.write("Regression test for file path return value")
+
+        # Verify it returns a file path (not directory)
+        assert_match(/\.s\.md$/, path), "Should return .s.md file path"
+
+        # Verify the path points to a file, not a directory
+        # (In our mock, we can verify the write_calls were made to the file)
+        assert @write_calls.any? { |call| call[:path] == path },
+               "Returned path should match the file that was written"
+
+        # Verify the directory component exists in mkdir_calls
+        folder_path = File.dirname(path)
+        assert @mkdir_calls.include?(folder_path),
+               "Parent directory should have been created"
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR fixes ace-taskflow idea creation to show the complete file path instead of just the directory path in the output.

## Changes

- Modified `IdeaWriter#write()` to return full file path instead of directory path
- Added YARD documentation to `IdeaWriter#write` method with detailed parameter and return documentation
- Added regression test `test_write_returns_file_path_not_directory` to ensure file path is returned
- Updated all related tests to expect file paths in return values

## Impact

Users now see the complete path to the created `.s.md` file, making it easier to navigate directly to the file.

**Before:**
```
Idea captured: .ace-taskflow/v.0.9.0/ideas/20251113-105651-taskflow-test
```

**After:**
```
Idea captured: .ace-taskflow/v.0.9.0/ideas/20251113-105651-taskflow-test/test-creation-of-the-idea.s.md
```

## Test Coverage

- ✅ Regression test added for file path output verification
- ✅ All existing tests updated and passing
- ✅ YARD documentation added for maintainability

## Task Reference

- Task-Ref: v.0.9.0+109 (completed)