### PR TITLE
143.01: Migrate ace-taskflow Configuration

### DIFF
--- a/.ace-taskflow/v.0.9.0/retros/2025-12-27-pr-review-false-positives.md
+++ b/.ace-taskflow/v.0.9.0/retros/2025-12-27-pr-review-false-positives.md
@@ -1,0 +1,135 @@
+# Reflection: PR Review False Positives Analysis
+
+**Date**: 2025-12-27
+**Context**: Analysis of high false positive rate in multi-model PR review for task 143.01
+**Author**: Claude Code (Opus 4.5)
+**Type**: Conversation Analysis
+
+## What Went Well
+
+- Verification workflow (review-pr.wf.md Step 3) caught all false positives before wasted implementation effort
+- Multi-model approach (5 models) provided diverse perspectives even if some were wrong
+- Review completed in reasonable time (~5 min for 5 models + synthesis)
+- The one valid suggestion (warning message clarity) was correctly identified and implemented
+
+## What Could Be Improved
+
+- 62.5% false positive rate (5/8 action items were invalid)
+- All 5 Critical/High priority items were false positives - the most important items were least reliable
+- Time spent verifying each claim (~15-20 min of grep/read verification)
+- Synthesis model didn't filter obvious hallucinations before including them
+
+## Key Learnings
+
+- Diff-only context creates a verification gap that LLMs cannot bridge
+- LLMs confidently assert claims about codebase state they cannot actually see
+- Critical/High priority from synthesis ≠ accuracy - in this case, higher priority meant less accurate
+- The human verification step is essential, not optional
+
+## Conversation Analysis (For conversation-based reflections)
+
+### Challenge Patterns Identified
+
+#### High Impact Issues
+
+- **LLM Hallucination About File Content**: Models claimed files lacked content that existed
+  - Occurrences: 3 (status section, strict_transitions docs, trailing newline)
+  - Impact: Each required grep/read verification to disprove; wasted verification cycles
+  - Root Cause: LLMs only see git diff, not full file content
+
+- **Incorrect Security Warnings**: Model claimed YAML.load security issue where none existed
+  - Occurrences: 1 (Critical priority)
+  - Impact: Highest priority item was completely false; eroded trust in review priorities
+  - Root Cause: Model saw test file manipulation code and assumed insecure pattern
+
+- **Dependency False Alarm**: Model claimed ace-support-core dependency issue
+  - Occurrences: 1 (High priority)
+  - Impact: Required gemspec and version file verification
+  - Root Cause: Model couldn't verify gem versions or class existence across files
+
+#### Medium Impact Issues
+
+- **Style Claims About Correct Code**: Model claimed inline comments where comments were correct
+  - Occurrences: 1
+  - Impact: Required reading source to verify comment placement
+  - Root Cause: Model couldn't see full method context from diff alone
+
+#### Low Impact Issues
+
+- None identified - all false positives were at least medium impact due to verification time
+
+### Improvement Proposals
+
+#### Process Improvements
+
+- Consider adding "confidence level" to synthesis based on whether claim is verifiable from diff alone
+- Document patterns that commonly produce false positives (file existence, EOF content, cross-file references)
+- Weight developer feedback higher than LLM-only findings in synthesis
+
+#### Tool Enhancements
+
+- **ace-review**: Add optional `--context-lines N` to include surrounding code in review
+- **ace-review**: Add post-review grep check for "class X doesn't exist" type claims
+- **ace-review**: Add `--full-files` option for thorough reviews
+- **Synthesis prompt**: Instruct synthesis model to flag claims requiring codebase verification
+
+#### Communication Protocols
+
+- Synthesis should explicitly note which claims are verifiable from diff vs require codebase inspection
+- Action items should include "verification method" (grep for class, check EOF, read config)
+
+### Token Limit & Truncation Issues
+
+- **Large Output Instances**: None - review output was manageable
+- **Truncation Impact**: N/A
+- **Mitigation Applied**: N/A
+- **Prevention Strategy**: Current diff-only approach is token-efficient but causes accuracy issues
+
+## Action Items
+
+### Stop Doing
+
+- Trusting Critical/High priority LLM claims without verification
+- Assuming LLMs can verify file content/existence claims from diff alone
+
+### Continue Doing
+
+- Manual verification of all Critical/High priority items before implementation
+- Using multi-model review for diverse perspectives
+- Following review-pr.wf.md verification workflow
+
+### Start Doing
+
+- Consider capturing an idea for enhanced ace-review context options
+- Track false positive rates across reviews to identify improvement opportunities
+- Flag review findings that require codebase verification vs diff-verifiable
+
+## Technical Details
+
+### Specific False Positives
+
+| Claim | Priority | Reality | How Verified |
+|-------|----------|---------|--------------|
+| YAML.load in tests | Critical | No YAML.load usage | `grep "YAML\.load[^_]" test/` |
+| Missing status section | High | Exists at lines 62-67 | `grep "status:" config.yml` |
+| ace-support-core dep | High | Correctly ~> 0.11 | Read gemspec line 34 |
+| Inline comment style | Medium | Comments above methods | Read configuration.rb:138-145 |
+| Missing EOF newline | Medium | Has trailing 0x0a | `tail -c 5 config.yml \| xxd` |
+| strict_transitions docs | Low | Documented lines 28-30 | Read config.yml |
+
+### Root Cause: ace-review Architecture
+
+The review system (`ace-review/lib/ace/review/organisms/review_manager.rb:247`) passes only the git diff to reviewers:
+
+```ruby
+subject: result[:diff]  # Only diff, not full files
+```
+
+This is a deliberate token-efficiency choice but creates blind spots for verification claims.
+
+## Additional Context
+
+- PR: #94 (143.01: Migrate ace-taskflow Configuration)
+- Session: `.cache/ace-review/sessions/review-20251227-201809/`
+- Synthesis report: `synthesis-report.md` in session directory
+- Workflow reference: `ace-review/handbook/workflow-instructions/review-pr.wf.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.198] - 2025-12-27
+
+### ace-taskflow v0.24.5 → v0.25.0
+
+**Added**
+- Migrate configuration to ADR-022 pattern with `.ace.example/` defaults
+  - Load defaults from `.ace.example/taskflow/` at runtime
+  - Merge user config over defaults using deep merge
+  - Support backward compatibility for renamed keys
+
+**Fixed**
+- Improve warning message clarity for missing example config
+- Address PR review feedback for configuration loading
+- Restore richer idea.template format with full metadata structure
+
 ## [0.9.197] - 2025-12-27
 
 ### ace-git-commit v0.12.3 → v0.12.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ PATH
 PATH
   remote: ace-taskflow
   specs:
-    ace-taskflow (0.24.5)
+    ace-taskflow (0.25.0)
       ace-git (~> 0.3)
       ace-support-core (~> 0.11)
       ace-support-mac-clipboard (~> 0.1.0)

--- a/ace-taskflow/.ace.example/taskflow/config.yml
+++ b/ace-taskflow/.ace.example/taskflow/config.yml
@@ -68,8 +68,28 @@ taskflow:
 
   # Idea configuration
   idea:
-    directory: "./ideas"         # Where to save ideas locally
+    directory: "ideas"           # Where to save ideas locally
+    template: |
+      # %{title}
+
+      ## Description
+      %{content}
+
+      ## Metadata
+      - **Captured**: %{timestamp}
+      - **Author**: %{author}
+      - **Status**: unprocessed
+    file_naming:
+      pattern: "%{timestamp}-%{title}"
+      timestamp_format: "%Y%m%d-%H%M%S"
+
+  # Task configuration
+  task:
+    directory: "."               # Task directory within release (default: .)
+    use_release_dirs: true       # Use version directories for tasks (default: true)
+    tasks_subdir: "t"            # Subdirectory for tasks within release (default: t)
 
   # Release configuration
   release:
-    current: "0.1.0"            # Your current release version
+    current: "."                 # Current release directory (default: .)
+    completed: "done"            # Completed release directory (default: done)

--- a/ace-taskflow/CHANGELOG.md
+++ b/ace-taskflow/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to ace-taskflow will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - 2025-12-27
+
+### Added
+
+- Migrate configuration to ADR-022 pattern with `.ace.example/` defaults
+  - Load defaults from `.ace.example/taskflow/` at runtime
+  - Merge user config over defaults using deep merge
+  - Support backward compatibility for renamed keys
+
+### Fixed
+
+- Improve warning message clarity for missing example config
+- Address PR review feedback for configuration loading
+- Add warning when example config not found
+- Restore richer idea.template format with full metadata structure
+
 ## [0.24.5] - 2025-12-26
 
 ### Technical

--- a/ace-taskflow/lib/ace/taskflow/configuration.rb
+++ b/ace-taskflow/lib/ace/taskflow/configuration.rb
@@ -136,18 +136,21 @@ module Ace
       end
 
       # Get idea-specific configuration
+      # Defaults come from .ace.example/taskflow/config.yml via ConfigLoader
       def idea_config
-        config["idea"] || default_idea_config
+        config["idea"] || {}
       end
 
       # Get task-specific configuration
+      # Defaults come from .ace.example/taskflow/config.yml via ConfigLoader
       def task_config
-        config["task"] || default_task_config
+        config["task"] || {}
       end
 
       # Get release-specific configuration
+      # Defaults come from .ace.example/taskflow/config.yml via ConfigLoader
       def release_config
-        config["release"] || default_release_config
+        config["release"] || {}
       end
 
       # Reload configuration
@@ -182,98 +185,25 @@ module Ace
         FileUtils.mkdir_p(File.join(root_directory, config_obj.done_dir))
 
         # Create initial .ace/taskflow/config.yml if not exists
+        # Copy from gem's .ace.example/ as the source of truth (ADR-022)
         taskflow_dir = File.join(Dir.pwd, ".ace", "taskflow")
         FileUtils.mkdir_p(taskflow_dir)
 
         config_file = File.join(taskflow_dir, "config.yml")
         unless File.exist?(config_file)
-          File.write(config_file, default_config_yaml)
+          # Copy from gem's .ace.example/ directory
+          gem_root = File.expand_path("../../..", __dir__)
+          example_config = File.join(gem_root, ".ace.example", "taskflow", "config.yml")
+
+          if File.exist?(example_config)
+            FileUtils.cp(example_config, config_file)
+          else
+            warn "Warning: Default config template not found at #{example_config} for ace-taskflow. " \
+                 "This may indicate a gem packaging issue."
+          end
         end
 
         true
-      end
-
-      private
-
-      def default_idea_config
-        {
-          "directory" => "ideas",
-          "template" => "# %{title}\n\n%{content}\n\n---\nCaptured: %{timestamp}",
-          "file_naming" => {
-            "pattern" => "%{timestamp}-%{title}",
-            "timestamp_format" => "%Y%m%d-%H%M%S"
-          }
-        }
-      end
-
-      def default_task_config
-        {
-          "directory" => ".",
-          "use_release_dirs" => true,
-          "tasks_subdir" => "t"
-        }
-      end
-
-      def default_release_config
-        {
-          "current" => ".",
-          "completed" => "done"
-        }
-      end
-
-      def default_config_yaml
-        <<~YAML
-          # ace-taskflow configuration
-
-          taskflow:
-            # Root directory for all taskflow data
-            root: ".ace-taskflow"
-
-            # Task directory name
-            task_dir: "t"
-
-            # Directory structure (underscore prefix for system directories)
-            directories:
-              completed: "_archive"         # Completed tasks/ideas
-              backlog: "_backlog"           # Future releases
-              deferred: "_deferred"         # Tasks to revisit later
-              parked: "_parked"             # Ideas that are good but not now
-
-            # Release management
-            active_strategy: "lowest"          # How to pick primary active release
-            allow_multiple_active: true        # Allow multiple active releases
-
-            # Qualified references
-            references:
-              allow_qualified: true            # Enable v.0.9.0+018 syntax
-              allow_cross_release: true        # Can reference other releases
-
-            # Default releases
-            defaults:
-              idea_location: "active"          # Where ideas go by default
-              task_location: "active"          # Where new tasks go by default
-
-            # Display parameters
-            params:
-              subtasks: enabled               # Show subtasks in task list (enabled/disabled)
-
-            # Idea configuration
-            idea:
-              directory: "ideas"
-              template: |
-                # %{title}
-
-                ## Description
-                %{content}
-
-                ## Metadata
-                - **Captured**: %{timestamp}
-                - **Author**: %{author}
-                - **Status**: unprocessed
-              file_naming:
-                pattern: "%{timestamp}-%{title}"
-                timestamp_format: "%Y%m%d-%H%M%S"
-        YAML
       end
     end
 

--- a/ace-taskflow/lib/ace/taskflow/molecules/config_loader.rb
+++ b/ace-taskflow/lib/ace/taskflow/molecules/config_loader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "yaml"
+require "ace/core/atoms/deep_merger"
 
 module Ace
   module Taskflow
@@ -29,7 +30,7 @@ module Ace
                     "This is a gem packaging error - .ace.example/ must be included in the gem."
             end
 
-            content = YAML.load_file(default_file)
+            content = YAML.safe_load_file(default_file, permitted_classes: [], aliases: true)
             extract_taskflow_config(content&.dig("taskflow") || {})
           end
         end
@@ -40,6 +41,7 @@ module Ace
         end
 
         # Load configuration from cascade
+        # Uses Ace::Core::Atoms::DeepMerger for consistent merging
         # @return [Hash] Merged configuration
         def self.load
           config = load_gem_defaults.dup
@@ -47,7 +49,7 @@ module Ace
           # Look for config files in cascade order
           find_config_paths.each do |path|
             if File.exist?(path)
-              config = deep_merge(config, load_file(path))
+              config = Ace::Core::Atoms::DeepMerger.merge(config, load_file(path))
             end
           end
 
@@ -134,7 +136,7 @@ module Ace
         end
 
         def self.load_file(path)
-          content = YAML.load_file(path)
+          content = YAML.safe_load_file(path, permitted_classes: [], aliases: true)
           return {} unless content.is_a?(Hash)
 
           # Extract taskflow section if present
@@ -196,23 +198,10 @@ module Ace
           config["tasks"] = taskflow_section["tasks"] if taskflow_section["tasks"]
           config["release"] = taskflow_section["release"] if taskflow_section["release"]
           config["params"] = taskflow_section["params"] if taskflow_section["params"]
+          config["status"] = taskflow_section["status"] if taskflow_section["status"]
           config["terminal_statuses"] = taskflow_section["terminal_statuses"] if taskflow_section["terminal_statuses"]
 
           config
-        end
-
-        def self.deep_merge(hash1, hash2)
-          result = hash1.dup
-
-          hash2.each do |key, value|
-            if result[key].is_a?(Hash) && value.is_a?(Hash)
-              result[key] = deep_merge(result[key], value)
-            else
-              result[key] = value
-            end
-          end
-
-          result
         end
       end
     end

--- a/ace-taskflow/lib/ace/taskflow/version.rb
+++ b/ace-taskflow/lib/ace/taskflow/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Taskflow
-    VERSION = "0.24.5"
+    VERSION = "0.25.0"
   end
 end

--- a/ace-taskflow/test/molecules/config_loader_test.rb
+++ b/ace-taskflow/test/molecules/config_loader_test.rb
@@ -364,4 +364,43 @@ class ConfigLoaderTest < AceTaskflowTestCase
     end
   end
 
+  def test_status_activity_section_is_extracted
+    Ace::Taskflow::Molecules::ConfigLoader.reset_gem_defaults!
+
+    with_test_project do |dir|
+      config_dir = File.join(dir, ".ace", "taskflow")
+      FileUtils.mkdir_p(config_dir)
+      File.write(File.join(config_dir, "config.yml"), <<~YAML)
+        taskflow:
+          status:
+            activity:
+              recently_done_limit: 5
+              up_next_limit: 10
+              include_drafts: true
+      YAML
+
+      Dir.chdir(dir) do
+        config = Ace::Taskflow::Molecules::ConfigLoader.load
+
+        # Verify status section is properly extracted
+        assert_kind_of Hash, config["status"]
+        assert_equal 5, config["status"]["activity"]["recently_done_limit"]
+        assert_equal 10, config["status"]["activity"]["up_next_limit"]
+        assert_equal true, config["status"]["activity"]["include_drafts"]
+      end
+    end
+  end
+
+  def test_gem_defaults_have_status_section
+    Ace::Taskflow::Molecules::ConfigLoader.reset_gem_defaults!
+    defaults = Ace::Taskflow::Molecules::ConfigLoader.load_gem_defaults
+
+    # Verify status activity defaults are present
+    assert_kind_of Hash, defaults["status"]
+    assert_kind_of Hash, defaults["status"]["activity"]
+    assert_equal 3, defaults["status"]["activity"]["recently_done_limit"]
+    assert_equal 3, defaults["status"]["activity"]["up_next_limit"]
+    assert_equal false, defaults["status"]["activity"]["include_drafts"]
+  end
+
 end

--- a/ace-taskflow/test/organisms/configuration_test.rb
+++ b/ace-taskflow/test/organisms/configuration_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../lib/ace/taskflow/configuration"
+
+class ConfigurationTest < AceTaskflowTestCase
+  # ADR-022: Configuration copies example config on initialization
+
+  def test_initialize_structure_creates_directories
+    Dir.mktmpdir do |dir|
+      TestFactory.with_stubbed_project_root(dir) do
+        Dir.chdir(dir) do
+          # Create minimal taskflow directory for find_root to succeed
+          taskflow_root = File.join(dir, ".ace-taskflow")
+          FileUtils.mkdir_p(taskflow_root)
+
+          config = Ace::Taskflow::Configuration.new
+          config.initialize_structure!
+
+          # Verify standard directories were created
+          assert Dir.exist?(File.join(taskflow_root, config.backlog_dir)),
+                 "backlog directory should exist"
+          assert Dir.exist?(File.join(taskflow_root, config.done_dir)),
+                 "done directory should exist"
+        end
+      end
+    end
+  end
+
+  def test_initialize_structure_copies_example_config_when_missing
+    Dir.mktmpdir do |dir|
+      TestFactory.with_stubbed_project_root(dir) do
+        Dir.chdir(dir) do
+          # Create minimal taskflow directory for find_root to succeed
+          taskflow_root = File.join(dir, ".ace-taskflow")
+          FileUtils.mkdir_p(taskflow_root)
+
+          # Verify no config exists yet
+          config_file = File.join(dir, ".ace", "taskflow", "config.yml")
+          refute File.exist?(config_file), "config.yml should not exist before initialization"
+
+          config = Ace::Taskflow::Configuration.new
+          config.initialize_structure!
+
+          # Verify config was created from gem's example
+          assert File.exist?(config_file), "config.yml should be created from example"
+
+          # Verify it has expected content from .ace.example/
+          content = File.read(config_file)
+          assert_match(/taskflow:/, content, "config should have taskflow root key")
+          assert_match(/root:/, content, "config should have root setting")
+          assert_match(/idea:/, content, "config should have idea section")
+        end
+      end
+    end
+  end
+
+  def test_initialize_structure_does_not_overwrite_existing_config
+    Dir.mktmpdir do |dir|
+      TestFactory.with_stubbed_project_root(dir) do
+        Dir.chdir(dir) do
+          # Create minimal taskflow directory for find_root to succeed
+          taskflow_root = File.join(dir, ".ace-taskflow")
+          FileUtils.mkdir_p(taskflow_root)
+
+          # Create existing config (using default root so find_root succeeds)
+          config_dir = File.join(dir, ".ace", "taskflow")
+          FileUtils.mkdir_p(config_dir)
+          config_file = File.join(config_dir, "config.yml")
+          original_content = "# Custom config\ntaskflow:\n  root: .ace-taskflow\n  active_strategy: highest\n"
+          File.write(config_file, original_content)
+
+          config = Ace::Taskflow::Configuration.new
+          config.initialize_structure!
+
+          # Verify original config was preserved
+          assert_equal original_content, File.read(config_file),
+                       "existing config should not be overwritten"
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
## Summary

Migrate ace-taskflow configuration to ADR-022 pattern:

- Remove inline YAML string from `configuration.rb` (the `default_config_yaml` method)
- Move all defaults to `.ace.example/taskflow/config.yml`
- Update `config_loader.rb` to use `YAML.safe_load_file` and `Ace::Core::Atoms::DeepMerger`
- Remove deprecated custom `deep_merge` method in favor of ace-core utility

## Test Plan

- [x] All existing tests pass (1165 tests, 0 failures)
- [x] `ace-taskflow task 143` works correctly
- [x] Configuration loading from `.ace.example/` verified

---
Parent task: #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)