### PR TITLE
143.02: Migrate ace-git-worktree Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.200] - 2025-12-27
+
+### ace-git-worktree v0.6.1 → v0.7.0
+
+**Changed**
+- Migrate configuration to ADR-022 pattern
+  - Removed unused `DEFAULT_*` constants from Configuration module
+  - Configuration now fully delegated to ace-support-core cascade and `.ace.example` defaults
+  - Default values remain available via `WorktreeConfig::DEFAULT_CONFIG` model
+
 ## [0.9.199] - 2025-12-27
 
 ### ace-taskflow v0.24.6 → v0.25.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ PATH
 PATH
   remote: ace-git-worktree
   specs:
-    ace-git-worktree (0.6.1)
+    ace-git-worktree (0.7.0)
       ace-git (~> 0.4)
       ace-support-core (>= 0.9.0)
       ace-taskflow (>= 0.10.0)

--- a/ace-git-worktree/CHANGELOG.md
+++ b/ace-git-worktree/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2025-12-27
+
+### Changed
+- **Configuration**: Migrate to ADR-022 configuration pattern
+  - Removed unused `DEFAULT_*` constants from Configuration module
+  - Configuration now fully delegated to ace-support-core cascade and `.ace.example` defaults
+  - Reduces code duplication (~40 LOC) and aligns with project-wide configuration standards
+  - Default values remain available via `WorktreeConfig::DEFAULT_CONFIG` model
+
 ## [0.6.1] - 2025-12-27
 
 ### Changed

--- a/ace-git-worktree/lib/ace/git/worktree/configuration.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/configuration.rb
@@ -5,22 +5,12 @@ module Ace
     module Worktree
       # Configuration module
       #
-      # Provides default configuration and constants for the ace-git-worktree gem.
-      # This module serves as a central place for configuration settings.
+      # Provides constants and utility methods for the ace-git-worktree gem.
+      # Configuration values are loaded from .ace/git/worktree.yml via ace-core cascade.
+      # Default values are defined in WorktreeConfig::DEFAULT_CONFIG.
       module Configuration
         # Gem name and identifier
         GEM_NAME = "ace-git-worktree"
-
-        # Default configuration values
-        DEFAULT_ROOT_PATH = ".ace-wt"
-        DEFAULT_DIRECTORY_FORMAT = "task.{id}"
-        DEFAULT_BRANCH_FORMAT = "{id}-{slug}"
-        DEFAULT_COMMIT_MESSAGE_FORMAT = "chore(task-{id}): mark as in-progress, creating worktree"
-
-        # Default timeout values (in seconds)
-        DEFAULT_GIT_TIMEOUT = 30
-        DEFAULT_MISE_TIMEOUT = 5
-        DEFAULT_TASK_TIMEOUT = 10
 
         # File and directory names
         MISE_CONFIG_FILE = "mise.toml"
@@ -31,11 +21,6 @@ module Ace
 
         # Template variable patterns
         TEMPLATE_VARIABLES = %w[id task_id release slug].freeze
-
-        # Validation constraints
-        MAX_SLUG_LENGTH = 50
-        MIN_SLUG_LENGTH = 3
-        MAX_PATH_LENGTH = 4096
 
         # Git branch name restrictions
         FORBIDDEN_BRANCH_CHARS = /[~\^:\*\?\[\]]/
@@ -98,28 +83,6 @@ module Ace
           metadata_add_failed: "Failed to add worktree metadata",
           uncommitted_changes: "Worktree has uncommitted changes"
         }.freeze
-
-        # Load default configuration
-        #
-        # @return [Hash] Default configuration hash
-        def self.default_configuration
-          {
-            "root_path" => DEFAULT_ROOT_PATH,
-            "mise_trust_auto" => true,
-            "task" => {
-              "directory_format" => DEFAULT_DIRECTORY_FORMAT,
-              "branch_format" => DEFAULT_BRANCH_FORMAT,
-              "auto_mark_in_progress" => true,
-              "auto_commit_task" => true,
-              "commit_message_format" => DEFAULT_COMMIT_MESSAGE_FORMAT,
-              "add_worktree_metadata" => true
-            },
-            "cleanup" => {
-              "on_merge" => false,
-              "on_delete" => true
-            }
-          }
-        end
 
         # Validate template variables
         #

--- a/ace-git-worktree/lib/ace/git/worktree/version.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/version.rb
@@ -3,7 +3,7 @@
 module Ace
   module Git
     module Worktree
-      VERSION = "0.6.1"
+      VERSION = "0.7.0"
     end
   end
 end


### PR DESCRIPTION
## Summary

Remove unused `DEFAULT_*` constants from the Configuration module:

- The constants were dead code - none were referenced anywhere in the codebase
- Each molecule already defines its own timeout constants locally
- `Models::WorktreeConfig` has a comprehensive `DEFAULT_CONFIG` hash as the canonical source
- The cascade via `Ace::Core.get(*CONFIG_NAMESPACE)` was already working correctly

**Constants removed:**
- `DEFAULT_ROOT_PATH`, `DEFAULT_DIRECTORY_FORMAT`, `DEFAULT_BRANCH_FORMAT`
- `DEFAULT_COMMIT_MESSAGE_FORMAT`
- `DEFAULT_GIT_TIMEOUT`, `DEFAULT_MISE_TIMEOUT`, `DEFAULT_TASK_TIMEOUT`
- `MAX_SLUG_LENGTH`, `MIN_SLUG_LENGTH`, `MAX_PATH_LENGTH`
- `self.default_configuration` method

## Test Plan

- [x] All 380 tests pass (0 failures)
- [x] Configuration loading verified through existing tests

---
Parent task: #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)