### PR TITLE
149.05: Migrate ace-review to Base36 Compact IDs

### DIFF
--- a/ace-review/ace-review.gemspec
+++ b/ace-review/ace-review.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   # Runtime dependencies
   spec.add_dependency 'thor', '~> 1.3' # Required for repeatable: true option support
   spec.add_dependency 'ace-config', '~> 0.4'
+  spec.add_dependency 'ace-timestamp', '~> 0.1'
   spec.add_dependency 'ace-support-core', '~> 0.9' # For ProcessTerminator
   spec.add_dependency 'ace-context', '~> 0.9'
   spec.add_dependency 'ace-git', '~> 0.3'

--- a/ace-review/lib/ace/review/molecules/task_report_saver.rb
+++ b/ace-review/lib/ace/review/molecules/task_report_saver.rb
@@ -2,11 +2,12 @@
 
 require "fileutils"
 require "time"
+require "ace/timestamp"
 
 module Ace
   module Review
     module Molecules
-      # Save review reports to task directories with timestamped filenames
+      # Save review reports to task directories with compact ID filenames
       class TaskReportSaver
         # Save a review report to a task's reviews/ directory
         # @param task_dir [String] Path to the task directory
@@ -78,17 +79,17 @@ module Ace
           end
         end
 
-        # Generate timestamped filename for review report
+        # Generate filename with compact ID for review report
         # @param review_data [Hash] Review metadata (preset, model, report_type, etc.)
         # @return [String] Filename with format depending on report_type:
-        #   - synthesis: YYYYMMDD-HHMMSS-synthesis.md
-        #   - regular:   YYYYMMDD-HHMMSS-model-preset-review.md
+        #   - synthesis: {compact_id}-synthesis.md
+        #   - regular:   {compact_id}-model-preset-review.md
         def self.generate_filename(review_data)
-          timestamp = Time.now.strftime("%Y%m%d-%H%M%S")
+          compact_id = Ace::Timestamp.encode(Time.now)
 
           # Handle synthesis reports with special filename format
           if review_data[:report_type] == 'synthesis'
-            return "#{timestamp}-synthesis.md"
+            return "#{compact_id}-synthesis.md"
           end
 
           # Use full model slug for uniqueness (e.g., "google:gemini-2.5-flash" -> "google-gemini-2-5-flash")
@@ -100,7 +101,7 @@ module Ace
           # Sanitize preset name for filename
           preset_slug = Ace::Review::Atoms::SlugGenerator.generate(preset)
 
-          "#{timestamp}-#{model_slug}-#{preset_slug}-review.md"
+          "#{compact_id}-#{model_slug}-#{preset_slug}-review.md"
         end
 
         # Extract provider name from model string

--- a/ace-review/lib/ace/review/organisms/review_manager.rb
+++ b/ace-review/lib/ace/review/organisms/review_manager.rb
@@ -5,6 +5,7 @@ require "time"
 require "yaml"
 require "open3"
 require "ace/support/fs"
+require "ace/timestamp"
 
 module Ace
   module Review
@@ -801,10 +802,10 @@ module Ace
           end
 
           # Use cache directory (cache-first approach)
-          timestamp = Time.now.strftime("%Y%m%d-%H%M%S")
+          compact_id = Ace::Timestamp.encode(Time.now)
 
           # All reviews use the same naming pattern
-          session_dir = File.join(cache_dir, "review-#{timestamp}")
+          session_dir = File.join(cache_dir, "review-#{compact_id}")
 
           FileUtils.mkdir_p(session_dir)
           session_dir
@@ -827,8 +828,8 @@ module Ace
 
           # Create output filename
           model_slug = Ace::Review::Atoms::SlugGenerator.generate(review_data[:model])
-          timestamp = Time.now.strftime("%Y%m%d-%H%M%S")
-          release_filename = "review-report-#{model_slug}-#{timestamp}.md"
+          compact_id = Ace::Timestamp.encode(Time.now)
+          release_filename = "review-report-#{model_slug}-#{compact_id}.md"
           release_path = File.join(release_base_path, release_filename)
 
           # Copy review file if it exists

--- a/ace-review/test/integration/auto_save_integration_test.rb
+++ b/ace-review/test/integration/auto_save_integration_test.rb
@@ -144,14 +144,16 @@ class AutoSaveIntegrationTest < Minitest::Test
     review_data = { report_type: 'synthesis' }
     filename = Ace::Review::Molecules::TaskReportSaver.generate_filename(review_data)
 
-    assert_match(/\d{8}-\d{6}-synthesis\.md$/, filename)
+    # Compact ID is 6 chars Base36 (0-9, a-z)
+    assert_match(/[0-9a-z]{6}-synthesis\.md$/, filename)
   end
 
   def test_generates_model_review_filename
     review_data = { model: "claude:opus", preset: "code-pr" }
     filename = Ace::Review::Molecules::TaskReportSaver.generate_filename(review_data)
 
-    assert_match(/\d{8}-\d{6}-claude-opus-code-pr-review\.md$/, filename)
+    # Compact ID is 6 chars Base36 (0-9, a-z)
+    assert_match(/[0-9a-z]{6}-claude-opus-code-pr-review\.md$/, filename)
   end
 
   # Test end-to-end flow (mocked)

--- a/ace-review/test/molecules/task_report_saver_test.rb
+++ b/ace-review/test/molecules/task_report_saver_test.rb
@@ -53,8 +53,9 @@ class TaskReportSaverTest < Minitest::Test
 
     filename = Ace::Review::Molecules::TaskReportSaver.generate_filename(review_data)
 
-    # Should match pattern: YYYYMMDD-HHMMSS-google-gemini-2-5-flash-pr-review.md
-    assert_match(/^\d{8}-\d{6}-google-gemini-2-5-flash-pr-review\.md$/, filename)
+    # Should match pattern: {compact_id}-google-gemini-2-5-flash-pr-review.md
+    # Compact ID is 6 chars Base36 (0-9, a-z)
+    assert_match(/^[0-9a-z]{6}-google-gemini-2-5-flash-pr-review\.md$/, filename)
   end
 
   def test_generate_filename_with_model_name
@@ -62,8 +63,9 @@ class TaskReportSaverTest < Minitest::Test
 
     filename = Ace::Review::Molecules::TaskReportSaver.generate_filename(review_data)
 
-    # Should match pattern: YYYYMMDD-HHMMSS-gpt-4-security-review.md
-    assert_match(/^\d{8}-\d{6}-gpt-4-security-review\.md$/, filename)
+    # Should match pattern: {compact_id}-gpt-4-security-review.md
+    # Compact ID is 6 chars Base36 (0-9, a-z)
+    assert_match(/^[0-9a-z]{6}-gpt-4-security-review\.md$/, filename)
   end
 
   def test_generate_filename_unique_for_same_provider_models
@@ -74,9 +76,10 @@ class TaskReportSaverTest < Minitest::Test
     filename_flash = Ace::Review::Molecules::TaskReportSaver.generate_filename(review_data_flash)
     filename_pro = Ace::Review::Molecules::TaskReportSaver.generate_filename(review_data_pro)
 
-    # Remove timestamp prefix to compare model portions
-    flash_suffix = filename_flash.sub(/^\d{8}-\d{6}-/, '')
-    pro_suffix = filename_pro.sub(/^\d{8}-\d{6}-/, '')
+    # Remove compact ID prefix to compare model portions
+    # Compact ID is 6 chars Base36 (0-9, a-z)
+    flash_suffix = filename_flash.sub(/^[0-9a-z]{6}-/, '')
+    pro_suffix = filename_pro.sub(/^[0-9a-z]{6}-/, '')
 
     # Filenames should be different (different model slugs)
     refute_equal flash_suffix, pro_suffix, "Same-provider models should produce different filenames"
@@ -98,8 +101,9 @@ class TaskReportSaverTest < Minitest::Test
 
     filename = Ace::Review::Molecules::TaskReportSaver.generate_filename(review_data)
 
-    # Should match pattern: YYYYMMDD-HHMMSS-synthesis.md
-    assert_match(/^\d{8}-\d{6}-synthesis\.md$/, filename)
+    # Should match pattern: {compact_id}-synthesis.md
+    # Compact ID is 6 chars Base36 (0-9, a-z)
+    assert_match(/^[0-9a-z]{6}-synthesis\.md$/, filename)
   end
 
   def test_extract_provider_from_prefixed_model

--- a/ace-review/test/organisms/review_manager_test.rb
+++ b/ace-review/test/organisms/review_manager_test.rb
@@ -179,7 +179,8 @@ class ReviewManagerTest < AceReviewTest
 
     refute_nil release_path
     assert File.exist?(release_path)
-    assert_match(/review-report-gpt-4-\d{8}-\d{6}\.md/, File.basename(release_path))
+    # Compact ID is 6 chars Base36 (0-9, a-z)
+    assert_match(/review-report-gpt-4-[0-9a-z]{6}\.md/, File.basename(release_path))
 
     release_content = File.read(release_path)
     assert_match(/# Review Report/, release_content)


### PR DESCRIPTION
## Summary

Migrates ace-review to use Base36 compact IDs (6 characters) for session directories and file naming. No backward compatibility - going "all in" with new format.

### Key Changes

- **ReviewManager**: Uses `Ace::Timestamp.encode(Time.now)` for session directories
- **TaskReportSaver**: Uses compact IDs for report filenames
- **Dependency**: Added `ace-timestamp ~> 0.1`

### New Filename Formats

| Before | After |
|--------|-------|
| `review-20250106-123456/` | `review-abc123/` |
| `20250106-123456-synthesis.md` | `abc123-synthesis.md` |

### Test Results

- All 478 tests pass (7 pre-existing skips)
- Updated test assertions for new format

## Test Plan

- [x] All tests pass (`ace-test ace-review`)
- [x] Base36 format used for new sessions
- [ ] Manual validation

---
Parent task: #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)