### PR TITLE
149.06: Migrate ace-docs to Base36 Compact IDs

### DIFF
--- a/ace-docs/ace-docs.gemspec
+++ b/ace-docs/ace-docs.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ace-config", "~> 0.5"
   spec.add_dependency "ace-support-core", "~> 0.11" # Requires PromptCacheManager
   spec.add_dependency "ace-git", "~> 0.3"
+  spec.add_dependency "ace-timestamp", "~> 0.1"
   spec.add_dependency "ace-llm", "~> 0.1"
   spec.add_dependency "ace-support-markdown", "~> 0.1"
   spec.add_dependency "thor", "~> 1.3"

--- a/ace-docs/lib/ace/docs/commands/analyze_command.rb
+++ b/ace-docs/lib/ace/docs/commands/analyze_command.rb
@@ -4,6 +4,7 @@ require_relative "../organisms/document_registry"
 require_relative "../molecules/change_detector"
 require_relative "../prompts/document_analysis_prompt"
 require "colorize"
+require "ace/timestamp"
 
 # Try to load ace-llm
 begin
@@ -111,8 +112,8 @@ module Ace
 
           # Create session directory for analysis
           cache_dir = Ace::Docs.config["cache_dir"] || ".cache/ace-docs"
-          timestamp = Time.now.strftime("%Y%m%d-%H%M%S")
-          session_dir = File.join(cache_dir, "analyze-#{timestamp}")
+          compact_id = Ace::Timestamp.encode(Time.now)
+          session_dir = File.join(cache_dir, "analyze-#{compact_id}")
           FileUtils.mkdir_p(session_dir)
 
           # Analyze with LLM

--- a/ace-docs/lib/ace/docs/models/analysis_report.rb
+++ b/ace-docs/lib/ace/docs/models/analysis_report.rb
@@ -2,6 +2,7 @@
 
 require "yaml"
 require "fileutils"
+require "ace/timestamp"
 
 module Ace
   module Docs
@@ -40,8 +41,8 @@ module Ace
           cache_dir ||= Ace::Docs.config["cache_dir"] || ".cache/ace-docs"
           FileUtils.mkdir_p(cache_dir)
 
-          timestamp = Time.now.strftime("%Y%m%d-%H%M%S")
-          filename = "analysis-#{timestamp}.md"
+          compact_id = Ace::Timestamp.encode(Time.now)
+          filename = "analysis-#{compact_id}.md"
           filepath = File.join(cache_dir, filename)
 
           File.write(filepath, to_markdown)

--- a/ace-docs/lib/ace/docs/molecules/change_detector.rb
+++ b/ace-docs/lib/ace/docs/molecules/change_detector.rb
@@ -6,6 +6,7 @@ require "fileutils"
 require "yaml"
 require "ace/git"
 require "ace/support/fs"
+require "ace/timestamp"
 
 module Ace
   module Docs
@@ -141,8 +142,8 @@ module Ace
         # @return [String] Path to saved analysis file
         def self.save_diff_to_cache(diff_result)
           cache_dir = ".cache/ace-docs"
-          timestamp = Time.now.strftime("%Y%m%d-%H%M%S")
-          session_dir = File.join(cache_dir, "diff-#{timestamp}")
+          compact_id = Ace::Timestamp.encode(Time.now)
+          session_dir = File.join(cache_dir, "diff-#{compact_id}")
 
           FileUtils.mkdir_p(session_dir)
 


### PR DESCRIPTION
## Summary

Migrates ace-docs to use Base36 compact IDs (6 characters) for session directories and file naming. No backward compatibility.

### Key Changes

- **AnalyzeCommand**: Uses `Ace::Timestamp.encode(Time.now)` for session directories
- **AnalysisReport**: Uses compact IDs for report filenames
- **ChangeDetector**: Uses compact IDs for diff directories
- **Dependency**: Added `ace-timestamp ~> 0.1`

### New Filename Formats

| Before | After |
|--------|-------|
| `analyze-20250106-123456/` | `analyze-abc123/` |
| `analysis-20250106-123456.md` | `analysis-abc123.md` |
| `diff-20250106-123456/` | `diff-abc123/` |

### Test Results

- All 153 tests pass (448 assertions, 0 failures)

## Test Plan

- [x] All tests pass (`ace-test ace-docs`)
- [x] Base36 format used for new sessions
- [ ] Manual validation

---
Parent task: #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)