### PR TITLE
149.07: Migrate ace-git-secrets to Base36 Compact IDs and Group Files

### DIFF
--- a/ace-git-secrets/ace-git-secrets.gemspec
+++ b/ace-git-secrets/ace-git-secrets.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency "ace-config", "~> 0.5"
+  spec.add_dependency "ace-timestamp", "~> 0.1"
   spec.add_dependency "faraday", "~> 2.7", ">= 2.7.4"
   spec.add_dependency "faraday-retry", "~> 2.2"
   spec.add_dependency "thor", "~> 1.3"

--- a/ace-git-secrets/lib/ace/git/secrets/models/scan_report.rb
+++ b/ace-git-secrets/lib/ace/git/secrets/models/scan_report.rb
@@ -3,6 +3,7 @@
 require "json"
 require "yaml"
 require "fileutils"
+require "ace/timestamp"
 
 module Ace
   module Git
@@ -194,11 +195,12 @@ module Ace
           # @return [String] Path to saved report file
           def save_to_file(format: :json, directory: nil, include_raw: true, quiet: false)
             cache_dir = directory || File.join(repository_path || ".", ".cache", "ace-git-secrets")
-            FileUtils.mkdir_p(cache_dir)
+            sessions_dir = File.join(cache_dir, "sessions")
+            FileUtils.mkdir_p(sessions_dir)
 
-            timestamp = scanned_at.strftime("%Y%m%d-%H%M%S")
+            session_id = Ace::Timestamp.encode(scanned_at)
             ext = format == :markdown ? "md" : "json"
-            path = File.join(cache_dir, "#{timestamp}-report.#{ext}")
+            path = File.join(sessions_dir, "#{session_id}-report.#{ext}")
 
             # JSON format includes raw values by default for revoke/rewrite-history workflows
             # Markdown format never includes raw values (human-readable)
@@ -211,20 +213,20 @@ module Ace
             end
 
             # Generate providers report for revocation workflow (only when tokens found)
-            save_providers_report(cache_dir, timestamp) if tokens_found?
+            save_providers_report(sessions_dir, session_id) if tokens_found?
 
             path
           end
 
           # Save providers-grouped markdown report for revocation workflow
-          # @param cache_dir [String] Directory to save report
-          # @param timestamp [String] Timestamp prefix for filename
+          # @param sessions_dir [String] Sessions directory to save report
+          # @param session_id [String] Session ID prefix for filename
           # @return [String, nil] Path to saved report, or nil if no tokens
-          def save_providers_report(cache_dir, timestamp)
+          def save_providers_report(sessions_dir, session_id)
             providers_content = to_providers_markdown
             return nil unless providers_content
 
-            providers_path = File.join(cache_dir, "#{timestamp}-providers.md")
+            providers_path = File.join(sessions_dir, "#{session_id}-providers.md")
             File.write(providers_path, providers_content)
             providers_path
           rescue StandardError => e

--- a/ace-git-secrets/lib/ace/git/secrets/organisms/history_cleaner.rb
+++ b/ace-git-secrets/lib/ace/git/secrets/organisms/history_cleaner.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "ace/timestamp"
+
 module Ace
   module Git
     module Secrets
@@ -164,9 +166,9 @@ module Ace
 
           # Generate default backup path
           def generate_backup_path
-            timestamp = Time.now.strftime("%Y%m%d-%H%M%S")
+            session_id = Ace::Timestamp.encode(Time.now)
             repo_name = File.basename(repository_path)
-            File.join(File.dirname(repository_path), "#{repo_name}-backup-#{timestamp}.git")
+            File.join(File.dirname(repository_path), "#{repo_name}-backup-#{session_id}.git")
           end
 
           # Instructions after successful rewrite

--- a/ace-git-secrets/test/commands/cli_test.rb
+++ b/ace-git-secrets/test/commands/cli_test.rb
@@ -89,9 +89,9 @@ class CLITest < GitSecretsTestCase
       assert_match(/Report saved:.*\.json/, output, "Should mention JSON report file")
       assert_equal 0, result
 
-      # Verify the JSON file was created
-      cache_dir = File.join(@mock_repo.path, ".cache", "ace-git-secrets")
-      json_files = Dir.glob(File.join(cache_dir, "*-report.json"))
+      # Verify the JSON file was created in sessions/ subdirectory
+      sessions_dir = File.join(@mock_repo.path, ".cache", "ace-git-secrets", "sessions")
+      json_files = Dir.glob(File.join(sessions_dir, "*-report.json"))
       assert json_files.any?, "JSON report file should exist"
 
       # Verify the JSON content

--- a/ace-git-secrets/test/integration/full_workflow_test.rb
+++ b/ace-git-secrets/test/integration/full_workflow_test.rb
@@ -79,9 +79,9 @@ class FullWorkflowIntegrationTest < GitSecretsTestCase
       assert_match(/Tokens found:/i, cli_output)
       assert_match(/SECURITY ALERT/i, cli_output)
 
-      # Verify the saved report file contains the details
-      cache_dir = File.join(@temp_repo, ".cache", "ace-git-secrets")
-      json_files = Dir.glob(File.join(cache_dir, "*-report.json"))
+      # Verify the saved report file contains the details in sessions/ subdirectory
+      sessions_dir = File.join(@temp_repo, ".cache", "ace-git-secrets", "sessions")
+      json_files = Dir.glob(File.join(sessions_dir, "*-report.json"))
       assert json_files.any?, "Report file should be saved"
     end
   end
@@ -99,9 +99,9 @@ class FullWorkflowIntegrationTest < GitSecretsTestCase
       # New behavior: JSON saved to file, summary to stdout
       assert_match(/Report saved:.*\.json/, output)
 
-      # Parse JSON from saved file
-      cache_dir = File.join(@temp_repo, ".cache", "ace-git-secrets")
-      json_files = Dir.glob(File.join(cache_dir, "*-report.json"))
+      # Parse JSON from saved file in sessions/ subdirectory
+      sessions_dir = File.join(@temp_repo, ".cache", "ace-git-secrets", "sessions")
+      json_files = Dir.glob(File.join(sessions_dir, "*-report.json"))
       assert json_files.any?, "JSON report file should exist"
 
       json_content = File.read(json_files.first)
@@ -321,9 +321,9 @@ class FullWorkflowIntegrationTest < GitSecretsTestCase
         )
       end
 
-      # Find the saved report file
-      cache_dir = File.join(@temp_repo, ".cache", "ace-git-secrets")
-      json_files = Dir.glob(File.join(cache_dir, "*-report.json"))
+      # Find the saved report file in sessions/ subdirectory
+      sessions_dir = File.join(@temp_repo, ".cache", "ace-git-secrets", "sessions")
+      json_files = Dir.glob(File.join(sessions_dir, "*-report.json"))
       assert json_files.any?, "Scan should save a JSON report file"
 
       scan_file = json_files.first

--- a/ace-git-secrets/test/models/scan_report_test.rb
+++ b/ace-git-secrets/test/models/scan_report_test.rb
@@ -153,8 +153,9 @@ class ScanReportTest < GitSecretsTestCase
     Dir.mktmpdir do |dir|
       report.save_to_file(directory: dir)
 
-      # Check that both files were created
-      files = Dir.glob(File.join(dir, "*"))
+      # Check that both files were created in sessions/ subdirectory
+      sessions_dir = File.join(dir, "sessions")
+      files = Dir.glob(File.join(sessions_dir, "*"))
       assert_equal 2, files.size
 
       report_file = files.find { |f| f.end_with?("-report.json") }
@@ -176,7 +177,9 @@ class ScanReportTest < GitSecretsTestCase
     Dir.mktmpdir do |dir|
       report.save_to_file(directory: dir)
 
-      files = Dir.glob(File.join(dir, "*"))
+      # Files are saved in sessions/ subdirectory
+      sessions_dir = File.join(dir, "sessions")
+      files = Dir.glob(File.join(sessions_dir, "*"))
       assert_equal 1, files.size
       assert files[0].end_with?("-report.json")
     end


### PR DESCRIPTION
## Summary

Migrates ace-git-secrets to use Base36 compact IDs (6 characters) for file naming AND groups files into sessions/ subdirectory. No backward compatibility.

### Key Changes

- **ScanReport**: Uses `Ace::Timestamp.encode(Time.now)` for session IDs
- **HistoryCleaner**: Uses compact IDs for backup naming
- **Directory Structure**: Files now saved to `sessions/` subdirectory
- **Dependency**: Added `ace-timestamp ~> 0.1`

### Directory Structure Change

| Before (scattered) | After (grouped) |
|--------------------|-----------------|
| `.cache/ace-git-secrets/20251222-144833-report.json` | `.cache/ace-git-secrets/sessions/abc123-report.json` |
| `.cache/ace-git-secrets/20251222-144833-providers.md` | `.cache/ace-git-secrets/sessions/abc123-providers.md` |

### Test Results

- All 160 tests pass (416 assertions, 0 failures)

## Test Plan

- [x] All tests pass (`ace-test ace-git-secrets`)
- [x] Base36 format used for new sessions
- [x] Files grouped in sessions/ subdirectory
- [ ] Manual validation

---
Parent task: #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)