### PR TITLE
feat: Improve report path resolution for failed packages in ace-test-suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.273] - 2026-01-08
+
+### Fixed
+
+- **ace-test-runner 0.10.2**: Report path resolution robustness and documentation (task 185)
+  - Fixed ReportPathResolver to check for directory existence
+  - Unified path handling and relative path output in FailedPackageReporter
+  - Add test coverage for relative path calculation errors
+
 ## [0.9.272] - 2026-01-08
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ PATH
 PATH
   remote: ace-test-runner
   specs:
-    ace-test-runner (0.10.1)
+    ace-test-runner (0.10.2)
       ace-config (~> 0.5)
       ace-support-core (~> 0.1)
       ace-support-test-helpers (~> 0.1)

--- a/ace-test-runner/CHANGELOG.md
+++ b/ace-test-runner/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-01-08
+
+### Fixed
+- Improved report path resolution robustness and documentation
+- Use relative paths in Markdown output and cleanup FailedPackageReporter
+
+### Technical
+- Add coverage for FailedPackageReporter relative path fallback
+
 ## [0.10.1] - 2026-01-08
 
 ### Fixed

--- a/ace-test-runner/lib/ace/test_runner.rb
+++ b/ace-test-runner/lib/ace/test_runner.rb
@@ -30,6 +30,7 @@ require_relative "test_runner/atoms/command_builder"
 require_relative "test_runner/atoms/result_parser"
 require_relative "test_runner/atoms/timestamp_generator"
 require_relative "test_runner/atoms/lazy_loader"
+require_relative "test_runner/atoms/report_path_resolver"
 
 # Molecules - Core operations (always needed for basic test running)
 require_relative "test_runner/molecules/test_executor"
@@ -38,6 +39,7 @@ require_relative "test_runner/molecules/report_storage"
 require_relative "test_runner/molecules/config_loader"
 require_relative "test_runner/molecules/pattern_resolver"
 require_relative "test_runner/molecules/cli_argument_parser"
+require_relative "test_runner/molecules/failed_package_reporter"
 # Other molecules loaded lazily (deprecation_fixer, rake_integration)
 
 # Formatters - Load only base formatter, others loaded on demand

--- a/ace-test-runner/lib/ace/test_runner/atoms/report_path_resolver.rb
+++ b/ace-test-runner/lib/ace/test_runner/atoms/report_path_resolver.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Ace
+  module TestRunner
+    module Atoms
+      module ReportPathResolver
+        module_function
+
+        REPORT_PRIORITY = [
+          "failures.json",
+          "summary.json",
+          "report.md",
+          "report.json",
+          "raw_output.txt"
+        ].freeze
+
+        # Resolves the best available report file path for a package
+        #
+        # The resolver checks for report files in the following priority order:
+        #   1. failures.json - Detailed failure information
+        #   2. summary.json - Summary of test results
+        #   3. report.md - Markdown formatted report
+        #   4. report.json - JSON formatted report
+        #   5. raw_output.txt - Raw test output
+        #
+        # @param package_path [String] The root path of the package
+        # @return [String, nil] The absolute path to the best available report file, or nil if none exist
+        def call(package_path)
+          return nil unless package_path && Dir.exist?(package_path)
+
+          reports_dir = File.join(package_path, "test-reports", "latest")
+          return nil unless Dir.exist?(reports_dir)
+
+          REPORT_PRIORITY.each do |filename|
+            path = File.join(reports_dir, filename)
+            return path if File.exist?(path)
+          end
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/ace-test-runner/lib/ace/test_runner/molecules/failed_package_reporter.rb
+++ b/ace-test-runner/lib/ace/test_runner/molecules/failed_package_reporter.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "pathname"
+require_relative "../atoms/report_path_resolver"
+
+module Ace
+  module TestRunner
+    module Molecules
+      module FailedPackageReporter
+        module_function
+
+        def format_for_display(package)
+          path = extract_path(package)
+          report_path = Atoms::ReportPathResolver.call(path)
+          
+          if report_path
+            begin
+              relative_path = Pathname.new(report_path).relative_path_from(Dir.pwd)
+              "    → See #{relative_path}"
+            rescue StandardError => e
+              warn "Failed to calculate relative path: #{e.message}" if debug_mode?
+              "    → See #{report_path}"
+            end
+          else
+            reports_path = File.join(path, "test-reports")
+            begin
+              relative_path = Pathname.new(reports_path).relative_path_from(Dir.pwd)
+              "    → Check #{relative_path}/ for details"
+            rescue StandardError => e
+              warn "Failed to calculate relative path: #{e.message}" if debug_mode?
+              "    → Check #{reports_path}/ for details"
+            end
+          end
+        end
+
+        def format_for_markdown(package)
+          path = extract_path(package)
+          report_path = Atoms::ReportPathResolver.call(path)
+
+          if report_path
+            relative_report_path = relative_or_absolute(report_path)
+            "- Report: `#{relative_report_path}`"
+          else
+            reports_path = File.join(path, "test-reports")
+            relative_reports_path = relative_or_absolute(reports_path)
+            "- Report: Check `#{relative_reports_path}/` for details"
+          end
+        end
+
+        class << self
+          private
+
+          def extract_path(package)
+            package[:path] || package["path"]
+          end
+
+          def debug_mode?
+            ENV["DEBUG"]
+          end
+
+          def relative_or_absolute(path)
+            Pathname.new(path).relative_path_from(Dir.pwd).to_s
+          rescue StandardError => e
+            warn "Failed to calculate relative path: #{e.message}" if debug_mode?
+            path
+          end
+        end
+      end
+    end
+  end
+end

--- a/ace-test-runner/lib/ace/test_runner/suite/display_manager.rb
+++ b/ace-test-runner/lib/ace/test_runner/suite/display_manager.rb
@@ -160,7 +160,7 @@ module Ace
             puts "Failed packages:"
             summary[:failed_packages].each do |pkg|
               puts "  - #{pkg[:name]}: #{pkg[:failures]} failures, #{pkg[:errors]} errors"
-              puts "    → See #{pkg[:path]}/test-reports/latest/failures.json"
+              puts Ace::TestRunner::Molecules::FailedPackageReporter.format_for_display(pkg)
             end
           end
 

--- a/ace-test-runner/lib/ace/test_runner/suite/result_aggregator.rb
+++ b/ace-test-runner/lib/ace/test_runner/suite/result_aggregator.rb
@@ -138,7 +138,7 @@ module Ace
               report << "- Failures: #{pkg[:failures]}"
               report << "- Errors: #{pkg[:errors]}"
               report << "- Error: #{pkg[:error_message]}" if pkg[:error_message]
-              report << "- Report: `#{pkg[:path]}/test-reports/latest/failures.json`"
+              report << Ace::TestRunner::Molecules::FailedPackageReporter.format_for_markdown(pkg)
               report << ""
             end
           end

--- a/ace-test-runner/lib/ace/test_runner/version.rb
+++ b/ace-test-runner/lib/ace/test_runner/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module TestRunner
-    VERSION = "0.10.1"
+    VERSION = "0.10.2"
   end
 end

--- a/ace-test-runner/test/atoms/report_path_resolver_test.rb
+++ b/ace-test-runner/test/atoms/report_path_resolver_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../lib/ace/test_runner/atoms/report_path_resolver"
+require "tmpdir"
+
+module Ace
+  module TestRunner
+    module Atoms
+      class ReportPathResolverTest < Minitest::Test
+        def setup
+          @temp_dir = Dir.mktmpdir
+          @reports_dir = File.join(@temp_dir, "test-reports", "latest")
+          FileUtils.mkdir_p(@reports_dir)
+        end
+
+        def teardown
+          FileUtils.remove_entry(@temp_dir)
+        end
+
+        def test_returns_failures_json_if_exists
+          create_file("failures.json")
+          create_file("summary.json") 
+          
+          path = ReportPathResolver.call(@temp_dir)
+          assert_equal File.join(@reports_dir, "failures.json"), path
+        end
+
+        def test_returns_summary_json_if_failures_missing
+          create_file("summary.json")
+          
+          path = ReportPathResolver.call(@temp_dir)
+          assert_equal File.join(@reports_dir, "summary.json"), path
+        end
+
+        def test_returns_report_md_if_json_missing
+          create_file("report.md")
+          
+          path = ReportPathResolver.call(@temp_dir)
+          assert_equal File.join(@reports_dir, "report.md"), path
+        end
+
+        def test_returns_nil_if_no_reports_exist
+          path = ReportPathResolver.call(@temp_dir)
+          assert_nil path
+        end
+
+        def test_returns_nil_if_reports_dir_does_not_exist
+          FileUtils.rm_rf(@reports_dir)
+          path = ReportPathResolver.call(@temp_dir)
+          assert_nil path
+        end
+
+        private
+
+        def create_file(name)
+          File.write(File.join(@reports_dir, name), "content")
+        end
+      end
+    end
+  end
+end

--- a/ace-test-runner/test/molecules/failed_package_reporter_test.rb
+++ b/ace-test-runner/test/molecules/failed_package_reporter_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../lib/ace/test_runner/molecules/failed_package_reporter"
+require "tmpdir"
+
+module Ace
+  module TestRunner
+    module Molecules
+      class FailedPackageReporterTest < Minitest::Test
+        def setup
+          @temp_dir = Dir.mktmpdir
+          @package_path = File.join(@temp_dir, "my-package")
+          @reports_dir = File.join(@package_path, "test-reports", "latest")
+          FileUtils.mkdir_p(@reports_dir)
+          @package = { path: @package_path }
+        end
+
+        def teardown
+          FileUtils.remove_entry(@temp_dir)
+        end
+
+        def test_format_for_display_with_existing_report
+          File.write(File.join(@reports_dir, "failures.json"), "{}")
+          
+          output = FailedPackageReporter.format_for_display(@package)
+          
+          # Should contain the path to failures.json
+          assert_match(/→ See .*failures\.json/, output)
+        end
+
+        def test_format_for_display_fallback
+          # No report files created
+          
+          output = FailedPackageReporter.format_for_display(@package)
+          
+          assert_match(/→ Check .*test-reports\/ for details/, output)
+        end
+
+        def test_format_for_markdown_with_existing_report
+          File.write(File.join(@reports_dir, "summary.json"), "{}")
+          
+          output = FailedPackageReporter.format_for_markdown(@package)
+          
+          assert_match(/- Report: `.*summary\.json`/, output)
+        end
+
+        def test_format_for_markdown_fallback
+          output = FailedPackageReporter.format_for_markdown(@package)
+          
+          assert_match(/- Report: Check `.*test-reports\/` for details/, output)
+        end
+
+        def test_format_for_display_handles_relative_path_error
+          File.write(File.join(@reports_dir, "failures.json"), "{}")
+          Pathname.stub :new, ->(_) { raise StandardError, "path calculation failed" } do
+            output = FailedPackageReporter.format_for_display(@package)
+            assert_match(/→ See /, output)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Improved the path resolution logic in \`ace-test-suite\` to ensure that users are directed to report files that actually exist when tests fail. This fixes the issue where the test runner would point to non-existent \`failures.json\` files.

### What Changed
- Created \`ReportPathResolver\` atom to check for existing report files in priority order (\`failures.json\`, \`summary.json\`, \`report.md\`, etc.).
- Created \`FailedPackageReporter\` molecule to format user-friendly messages based on available reports.
- Updated \`DisplayManager\` and \`ResultAggregator\` to use the dynamic reporter.

### Why This Feature
- **User Experience**: Users were being confused by error messages pointing to missing files.
- **Agentic Workflow**: AI agents (and humans) rely on accurate file paths to debug failures.

## Implementation Details

### New Components
- \`ace-test-runner/lib/ace/test_runner/atoms/report_path_resolver.rb\` - Pure function to find best matching report file.
- \`ace-test-runner/lib/ace/test_runner/molecules/failed_package_reporter.rb\` - Formatter for stdout and markdown reports.

### Modified Components
- \`ace-test-runner/lib/ace/test_runner/suite/display_manager.rb\` - Now uses \`FailedPackageReporter\` for console output.
- \`ace-test-runner/lib/ace/test_runner/suite/result_aggregator.rb\` - Now uses \`FailedPackageReporter\` for markdown reports.

## Testing

### Test Coverage
- Unit tests added for \`ReportPathResolver\` and \`FailedPackageReporter\`.
- Existing integration tests passed.

### Test Commands
\`\`\`bash
bin/ace-test ace-test-runner/test/atoms/report_path_resolver_test.rb
bin/ace-test ace-test-runner/test/molecules/failed_package_reporter_test.rb
bin/ace-test ace-test-runner
\`\`\`

## Checklist

- [x] Tests pass locally
- [x] Tests added for new functionality
- [x] Code follows project style guidelines
- [x] No breaking changes

## Related Issues
Closes #185