### PR TITLE
j82: recover non-migration code and config fixes from fix/e2e

### DIFF
--- a/.ace-retros/8r9koj-8r9kdv-01001-recover-ace-llm/8r9koj-8r9kdv-01001-recover-ace-llm-providers-cli.retro.md
+++ b/.ace-retros/8r9koj-8r9kdv-01001-recover-ace-llm/8r9koj-8r9kdv-01001-recover-ace-llm-providers-cli.retro.md
@@ -1,0 +1,26 @@
+---
+id: 8r9koj
+title: "8r9kdv@010.01 recover ace-llm-providers-cli fixes"
+type: standard
+tags: [assignment, 8r9kdv, 8r9.t.j82.0]
+created_at: "2026-04-10 13:47:16"
+status: active
+---
+
+# 8r9kdv@010.01 recover ace-llm-providers-cli fixes
+
+## What Went Well
+- Recovered the exact runtime/test hunks from `fix/e2e` without pulling unrelated migration work.
+- Kept changes narrowly scoped to `ace-llm-providers-cli` plus task/release metadata and changelogs.
+- Verified both implementation and profile-guided package test runs (`ace-test ace-llm-providers-cli` and `ace-test --profile 6`) with zero failures.
+- Completed subtree flow end-to-end: onboard, load, plan, implement, pre-commit gate, verify, release, retro.
+
+## What Could Be Improved
+- `ace-task update ... status=done` changed the task file after the implementation commit, requiring an extra follow-up task-spec commit.
+- Pre-commit fallback (`ace-lint`) surfaced formatting warnings in task spec markdown; these warnings are non-blocking but create noise in the review step.
+- `ace-task plan` path mode returned only a plan artifact path after a long-running command, so visibility into planning progress was limited.
+
+## Action Items
+- Consider normalizing task-spec markdown spacing in draft/review workflows to reduce pre-commit warning noise.
+- Consider tightening `work-on-task` guidance on when to commit task-status transitions to avoid extra post-release spec commits.
+- Investigate adding progress output or heartbeat logging for long-running `ace-task plan` execution.

--- a/.ace-retros/8r9l1t-retro-8r9kdv-01002-8r9tj821/8r9l1t-retro-8r9kdv-01002-8r9tj821.retro.md
+++ b/.ace-retros/8r9l1t-retro-8r9kdv-01002-8r9tj821/8r9l1t-retro-8r9kdv-01002-8r9tj821.retro.md
@@ -1,0 +1,26 @@
+---
+id: 8r9l1t
+title: "Retro 8r9kdv@010.02 (8r9.t.j82.1)"
+type: standard
+tags: [assignment, 8r9kdv, 8r9.t.j82.1]
+created_at: "2026-04-10 14:02:02"
+status: active
+---
+
+# Retro 8r9kdv@010.02 (8r9.t.j82.1)
+
+## What Went Well
+- Recovered the exact intended fix slice from `fix/e2e` using the task’s reference diff, avoiding scope creep.
+- Added and validated packaged-default regression coverage (`ace-git-commit/test/default_config_test.rb`) with full package tests passing.
+- Kept commits scoped and traceable (`fix`, task-spec updates, and release metadata separated by concern).
+- Completed subtree release updates (`ace-git-commit` version/changelogs + root changelog + lockfile) with a clean final tree.
+
+## What Could Be Improved
+- The pre-commit review step had no native `/review` path in this runtime; fallback linting worked but lacks deeper semantic review.
+- Release proof guidance in workflow used `--test-id`, but local CLI uses positional `TEST_ID`; this mismatch caused avoidable retry friction.
+- Monorepo E2E proof execution was unstable in this environment and required timeout bounding to produce a deterministic artifact.
+
+## Action Items
+- Update release workflow docs to include both accepted `ace-test-e2e` invocation shapes (flag vs positional) or align to the current CLI contract.
+- Add a small preflight check in release steps to detect unsupported options before long-running proof commands.
+- Track and investigate `TS-MONO-001` provider timeout behavior in this environment before treating release proofs as onboarding-safe.

--- a/.ace-retros/8r9lcl-retro-8r9kdv-01003-task-8r9tj822/8r9lcl-retro-8r9kdv-01003-task-8r9tj822.retro.md
+++ b/.ace-retros/8r9lcl-retro-8r9kdv-01003-task-8r9tj822/8r9lcl-retro-8r9kdv-01003-task-8r9tj822.retro.md
@@ -1,0 +1,26 @@
+---
+id: 8r9lcl
+title: "Retro: 8r9kdv@010.03 task 8r9.t.j82.2"
+type: standard
+tags: [assign, 8r9kdv, 8r9.t.j82.2]
+created_at: "2026-04-10 14:14:00"
+status: active
+---
+
+# Retro: 8r9kdv@010.03 task 8r9.t.j82.2
+
+## What Went Well
+- Recovered the intended `fix/e2e` behavior in `ace-llm` without pulling unrelated E2E role/config migration changes.
+- Added focused fallback regression coverage for per-target option rebuilding and selector suffix preservation.
+- Verification stayed fast and deterministic (`ace-test ace-llm` and `ace-test --profile 6` both passed cleanly).
+- Release artifacts were updated coherently (`ace-llm` version/changelog + root changelog + lockfile) with scoped commits.
+
+## What Could Be Improved
+- The pre-commit review step still relies on environment capability checks; `/review` was unavailable and required lint fallback.
+- Assignment session metadata for this subtree (`sessions/010.03-session.yml`) was missing, forcing provider fallback lookup from `.ace/assign/config.yml`.
+- Task status updates after release steps can leave spec files dirty; explicit guidance on when to commit those metadata-only updates would reduce ambiguity.
+
+## Action Items
+- Add a small guard/helper in assign pre-commit-review flow to emit explicit “session metadata missing” diagnostics with recommended fallback path.
+- Consider a dedicated assignment helper for committing task-status/spec metadata after subtree release and before retro closeout.
+- Keep extending fallback tests when selector grammar evolves (especially alias + `@preset` + `:thinking` combinations).

--- a/.ace-retros/8r9low-retro-8r9kdv-01004-task-8r9tj823/8r9low-retro-8r9kdv-01004-task-8r9tj823.retro.md
+++ b/.ace-retros/8r9low-retro-8r9kdv-01004-task-8r9tj823/8r9low-retro-8r9kdv-01004-task-8r9tj823.retro.md
@@ -1,0 +1,26 @@
+---
+id: 8r9low
+title: retro-8r9kdv-010.04-task-8r9.t.j82.3
+type: standard
+tags: [assignment, task-8r9.t.j82.3]
+created_at: "2026-04-10 14:27:40"
+status: active
+---
+
+# retro-8r9kdv-010.04-task-8r9.t.j82.3
+
+## What Went Well
+- Recovered the intended non-migration config slice from `fix/e2e` without pulling unrelated E2E migration files.
+- Enabled `output: cache` for `.ace/bundle/presets/project.md` and validated `ace-bundle project` still succeeds.
+- Restored all expected package entries in `.ace/test/suite.yml` and verified referenced package paths exist.
+- Kept release behavior safe by treating this subtree as no-op for package versioning because no `ace-*` package files changed.
+
+## What Could Be Improved
+- `ace-task plan 8r9.t.j82.3` (path mode) stalled with no output for over 3 minutes, adding delay to execution.
+- `ace-search` path-targeted checks were unreliable in this environment for single-file validation; fallback checks needed `rg`.
+- Markdown style warnings remained in the task spec file from template spacing conventions.
+
+## Action Items
+- Investigate and fix `ace-task plan <taskref>` no-output stall in fork execution sessions.
+- Harden `ace-search` single-file path resolution behavior or document known limitations in task workflows.
+- Consider normalizing task template markdown spacing to reduce repetitive lint warnings in task specs.

--- a/.ace-retros/8r9lwu-retro-8r9kdv-01005-task-8r9tj824/8r9lwu-retro-8r9kdv-01005-task-8r9tj824.retro.md
+++ b/.ace-retros/8r9lwu-retro-8r9kdv-01005-task-8r9tj824/8r9lwu-retro-8r9kdv-01005-task-8r9tj824.retro.md
@@ -1,0 +1,25 @@
+---
+id: 8r9lwu
+title: retro-8r9kdv-010.05-task-8r9.t.j82.4
+type: standard
+tags: [assignment, task-8r9.t.j82.4]
+created_at: "2026-04-10 14:36:30"
+status: active
+---
+
+# retro-8r9kdv-010.05-task-8r9.t.j82.4
+
+## What Went Well
+- Added the suite-completeness regression guard in `ace-test-runner` and verified it catches missing suite inventory entries.
+- The new guard immediately surfaced a real gap (`ace-monorepo-e2e` missing from `.ace/test/suite.yml`), which was fixed in the same task.
+- Verification stayed scoped and fast: `ace-test ace-test-runner` and `cd ace-test-runner && ace-test --profile 6` both passed cleanly.
+- Completed package release flow for `ace-test-runner` with coordinated version/changelog updates and clean working tree at closeout.
+
+## What Could Be Improved
+- Pre-commit review fallback had to rely on `ace-lint` because native `/review` invocation is not available in this execution environment.
+- Task-spec markdown spacing warnings are recurring and create noise during quality checks.
+
+## Action Items
+- Evaluate whether fork execution environments should expose native `/review` capability or a structured equivalent CLI review command.
+- Consider normalizing task spec markdown spacing conventions/templates to reduce repeated lint warning churn.
+- Add or document an automated check that keeps `.ace/test/suite.yml` aligned with discovered testable packages to reduce manual drift fixes.

--- a/.ace-retros/8r9m81-8r9tj825-worktree-fix-recovery/8r9m81-8r9tj825-worktree-fix-recovery.retro.md
+++ b/.ace-retros/8r9m81-8r9tj825-worktree-fix-recovery/8r9m81-8r9tj825-worktree-fix-recovery.retro.md
@@ -1,0 +1,34 @@
+---
+id: 8r9m81
+title: 8r9.t.j82.5 worktree fix recovery
+type: standard
+tags: [assignment, 8r9kdv, 8r9.t.j82.5]
+created_at: "2026-04-10 14:48:56"
+status: active
+---
+
+# 8r9.t.j82.5 worktree fix recovery
+
+## What Went Well
+- Recovered the intended `fix/e2e` behavior with narrow scope: `WorktreeRemover` cleanup failure now returns hard errors, and prune uses `--expire now`.
+- Added direct regression coverage for both acceptance points:
+  - prune arg enforcement (`--expire now`)
+  - stuck-directory failure behavior
+- Validation was clean at both targeted and package level:
+  - `ace-test ace-git-worktree/test/commands/prune_command_test.rb`
+  - `ace-test ace-git-worktree/test/molecules/worktree_remover_test.rb`
+  - `ace-test ace-git-worktree`
+- Release execution completed with package + root changelog updates and coordinated commits (`f220b3b8f`, `cc86910c9`).
+- RubyGems propagation proof succeeded on retry with final `SAFE` classification:
+  - `.ace-local/test-e2e/8r9m4k2-monorepo-e2e-ts001-reports/report.md`
+
+## What Could Be Improved
+- The release workflow text uses `--test-id` for `ace-test-e2e`, but current CLI expects positional `TEST_ID`; this caused avoidable first-attempt failure.
+- Initial TS-MONO-001 run was non-deterministic (`PARTIAL 3/4`) before passing on retry, indicating occasional environment/tooling flakiness in proof runs.
+- `ace-task update ... status=done` modified the task spec after earlier commit, leaving a residual uncommitted task-file change that should be intentionally handled in closeout steps.
+
+## Action Items
+- Add/update workflow guidance so TS-MONO-001 uses the current invocation form:
+  - `ace-test-e2e ace-monorepo-e2e TS-MONO-001`
+- Track and reduce TS-MONO-001 flake sources around Bundler directory-removal/full-index scenarios.
+- Add a closeout reminder/check in work-on-task or release flow to explicitly commit post-status task-spec mutations.

--- a/.ace-retros/8r9oei-batch-recovery-fix-e2e-followups/8r9oei-batch-recovery-fix-e2e-followups.retro.md
+++ b/.ace-retros/8r9oei-batch-recovery-fix-e2e-followups/8r9oei-batch-recovery-fix-e2e-followups.retro.md
@@ -1,0 +1,48 @@
+---
+id: 8r9oei
+title: batch-recovery-fix-e2e-followups
+type: standard
+tags: []
+created_at: "2026-04-10 16:16:07"
+status: active
+---
+
+# batch-recovery-fix-e2e-followups
+
+## What Went Well
+
+- Splitting the recovery into seven task subtrees kept each package fix small enough to release, verify, and retro independently before recombining the branch.
+- The review-valid, review-fit, and review-shine cycles found real integration gaps after the first pass, especially around legacy E2E path compatibility and stale public guidance.
+- Reorganizing the PR history by scope at the end made the branch readable again even after multiple release and review follow-up commits.
+- The final demo added reviewer-facing proof for the recovered path contract instead of relying only on test summaries.
+
+## What Could Be Improved
+
+- The `record-demo` step took several retries because tape command strings were not fail-closed enough against YAML comment parsing, shell quoting, sandbox cwd assumptions, and fixture-copy assumptions.
+- `update-pr-desc` stalled when `ace-assign fork-run --root 150` never created subtree session/report artifacts, which forced manual recovery late in the assignment.
+- The PR description workflow depends on `ace-taskflow status`, but that executable was not available in the bundled environment, so the forked worker had less chance of succeeding unattended.
+- Adding a new tracked demo tape after `reorganize-commits` required an extra commit and push outside the planned tail sequence.
+
+## Key Learnings
+
+- Shared migration work needs explicit compatibility coverage for both the new and legacy path contracts until all packages and docs switch together.
+- Late-stage demo recording is effectively another verification layer: it exposed command-shape problems that normal dry-run checks did not catch.
+- Assignment tail steps that can still create tracked source files should either run before commit reorganization or automatically inject a post-demo commit/push step.
+
+### Review Cycle Analysis
+
+- The first review cycle surfaced the highest-value correctness issues: mismatched scenario path expectations and separate runner/verifier provider enforcement.
+- Later cycles were still useful, but they shifted toward compatibility/documentation polish instead of core correctness, which is the right pattern for this kind of batch recovery.
+- Review findings that caused actual code changes clustered around integration seams, not the isolated package fixes themselves. That suggests future migration recoveries should bias testing and review toward cross-package contracts first.
+
+## Action Items
+
+- Stop doing: assume demo tape commands will behave like interactive shell commands without checking YAML parsing, working directory, and sandbox materialization explicitly.
+- Continue doing: recover large broken branches in releaseable subtrees, then run review cycles before the final history cleanup.
+- Start doing: add a lightweight pre-record linter for tape command strings and a fork-run health check that fails fast when no subtree session/report artifacts appear.
+
+## Additional Context
+
+- Assignment: `8r9kdv`
+- PR: `https://github.com/cs3b/ace/pull/288`
+- Demo asset: `https://github.com/cs3b/ace/releases/download/demo-assets/ace-test-runner-e2e-path-contract-recovery-1775837460.gif`

--- a/.ace-retros/_archive/8r/w/8r9mh8-8r9tj826-shared-e2e-contract-recovery/8r9mh8-8r9tj826-shared-e2e-contract-recovery.retro.md
+++ b/.ace-retros/_archive/8r/w/8r9mh8-8r9tj826-shared-e2e-contract-recovery/8r9mh8-8r9tj826-shared-e2e-contract-recovery.retro.md
@@ -1,0 +1,23 @@
+---
+id: 8r9mh8
+title: 8r9.t.j82.6 shared E2E contract recovery
+type: standard
+tags: [assign, 8r9kdv, 8r9.t.j82.6]
+created_at: "2026-04-10 14:59:09"
+status: done
+---
+
+# 8r9.t.j82.6 shared E2E contract recovery
+
+## What Went Well
+- Recovered the exact shared-contract delta from `fix/e2e` across all five targeted files without pulling package-local migration changes.
+- Kept execution/verification discipline tight: contract `rg` checks, `ace-test ace-assign`, and profile-guided package verification all passed.
+- Completed release follow-through with `ace-assign v0.44.4` and recorded propagation proof (`TS-MONO-001` classified `SAFE`).
+
+## What Could Be Improved
+- `release-minor` workflow text referenced `ace-test-e2e --test-id`, but current CLI expects positional `TEST_ID`; this caused one avoidable failed attempt.
+- The create-retro internal workflow payload is minimal; adding explicit command examples would reduce ambiguity in execution environments.
+
+## Action Items
+- Update release workflow docs to use the current `ace-test-e2e <package> <TEST_ID>` syntax.
+- Expand `wfi://assign/create-retro-internal` with explicit artifact expectations and recommended `ace-retro` command forms.

--- a/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/0-recover-ace-llm-providers-cli/8r9.t.j82.0-recover-ace-llm-providers-cli-fixes-from.s.md
+++ b/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/0-recover-ace-llm-providers-cli/8r9.t.j82.0-recover-ace-llm-providers-cli-fixes-from.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r9.t.j82.0
-status: pending
+status: done
 priority: medium
 created_at: "2026-04-10 13:01:09"
 estimate: TBD
@@ -38,14 +38,14 @@ needs_review: false
   - Gemini no longer performs separate project-root lookup for this path
 
 ## Success Criteria
-- [ ] Codex env propagation fix is specified.
-- [ ] Gemini env propagation and working-dir fixes are specified.
-- [ ] Regression tests covering both providers are included.
+- [x] Codex env propagation fix is specified.
+- [x] Gemini env propagation and working-dir fixes are specified.
+- [x] Regression tests covering both providers are included.
 
 ## Verification Plan
-- [ ] `ace-test ace-llm-providers-cli`
-- [ ] Confirm Codex test coverage asserts `SafeCapture` receives `env`.
-- [ ] Confirm Gemini test coverage asserts both `env` propagation and direct working-dir use.
+- [x] `ace-test ace-llm-providers-cli`
+- [x] Confirm Codex test coverage asserts `SafeCapture` receives `env`.
+- [x] Confirm Gemini test coverage asserts both `env` propagation and direct working-dir use.
 
 ## Out Of Scope
 - any model alias, role, or preset changes outside the bundled provider runtime files

--- a/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/1-recover-ace-git-commit-fixes/8r9.t.j82.1-recover-ace-git-commit-fixes-from-fixe2e.s.md
+++ b/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/1-recover-ace-git-commit-fixes/8r9.t.j82.1-recover-ace-git-commit-fixes-from-fixe2e.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r9.t.j82.1
-status: pending
+status: done
 priority: medium
 created_at: "2026-04-10 13:01:09"
 estimate: TBD
@@ -37,13 +37,13 @@ needs_review: false
   - defaults express the intended contract without requiring runtime behavior changes in this slice
 
 ## Success Criteria
-- [ ] `git.split.enabled` is specified as `true`.
-- [ ] `git.split.strategy` is specified as `config-scope`.
-- [ ] The regression test for packaged defaults is included.
+- [x] `git.split.enabled` is specified as `true`.
+- [x] `git.split.strategy` is specified as `config-scope`.
+- [x] The regression test for packaged defaults is included.
 
 ## Verification Plan
-- [ ] `ace-test ace-git-commit`
-- [ ] Confirm the bundled test asserts the `--no-split` override text.
+- [x] `ace-test ace-git-commit`
+- [x] Confirm the bundled test asserts the `--no-split` override text.
 
 ## Out Of Scope
 - changing the split algorithm itself

--- a/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/2-recover-ace-llm-fixes-from/8r9.t.j82.2-recover-ace-llm-fixes-from-fixe2e.s.md
+++ b/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/2-recover-ace-llm-fixes-from/8r9.t.j82.2-recover-ace-llm-fixes-from-fixe2e.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r9.t.j82.2
-status: pending
+status: done
 priority: medium
 created_at: "2026-04-10 13:01:09"
 estimate: TBD
@@ -43,14 +43,14 @@ needs_review: false
 - `.ace-defaults/llm/config.yml` role renames such as `e2e-executor` to `e2e-runner` and `e2e-verifier`
 
 ## Success Criteria
-- [ ] fallback selector parsing fixes are specified
-- [ ] per-target generation option rebuilding is specified
-- [ ] regression tests are included
+- [x] fallback selector parsing fixes are specified
+- [x] per-target generation option rebuilding is specified
+- [x] regression tests are included
 
 ## Verification Plan
-- [ ] `ace-test ace-llm`
-- [ ] Confirm integration coverage asserts provider-specific option rebuilding for fallback targets.
-- [ ] Confirm molecule coverage asserts provider/model selector parsing in the orchestrator.
+- [x] `ace-test ace-llm`
+- [x] Confirm integration coverage asserts provider-specific option rebuilding for fallback targets.
+- [x] Confirm molecule coverage asserts provider/model selector parsing in the orchestrator.
 
 ## Out Of Scope
 - project-level role rename changes in `.ace/llm/config.yml`

--- a/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/3-recover-main-monorepo-config-fixes/8r9.t.j82.3-recover-main-monorepo-config-fixes-from-fixe2e.s.md
+++ b/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/3-recover-main-monorepo-config-fixes/8r9.t.j82.3-recover-main-monorepo-config-fixes-from-fixe2e.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r9.t.j82.3
-status: pending
+status: done
 priority: medium
 created_at: "2026-04-10 13:01:09"
 estimate: TBD
@@ -56,11 +56,11 @@ needs_review: false
 - `.ace/tmux/**`
 
 ## Success Criteria
-- [ ] bundle preset cache enablement is specified
-- [ ] suite package additions are specified
-- [ ] migration-owned config changes stay excluded
+- [x] bundle preset cache enablement is specified
+- [x] suite package additions are specified
+- [x] migration-owned config changes stay excluded
 
 ## Verification Plan
-- [ ] suite package inventory matches the packages discovered on `fix/e2e`
-- [ ] Confirm `.ace/bundle/presets/project.md` enables cached output.
-- [ ] Confirm no shared role/path contract file is bundled here.
+- [x] suite package inventory matches the packages discovered on `fix/e2e`
+- [x] Confirm `.ace/bundle/presets/project.md` enables cached output.
+- [x] Confirm no shared role/path contract file is bundled here.

--- a/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/4-recover-ace-test-runner-fixes/8r9.t.j82.4-recover-ace-test-runner-fixes-from-fixe2e.s.md
+++ b/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/4-recover-ace-test-runner-fixes/8r9.t.j82.4-recover-ace-test-runner-fixes-from-fixe2e.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r9.t.j82.4
-status: pending
+status: done
 priority: medium
 created_at: "2026-04-10 13:01:09"
 estimate: TBD
@@ -37,12 +37,12 @@ needs_review: false
   - this child remains dependent on the suite inventory child
 
 ## Success Criteria
-- [ ] the suite completeness test is specified
-- [ ] the task depends on the monorepo config package inventory task
+- [x] the suite completeness test is specified
+- [x] the task depends on the monorepo config package inventory task
 
 ## Verification Plan
-- [ ] `ace-test ace-test-runner`
-- [ ] Confirm the regression test reports missing package names when the suite inventory is incomplete.
+- [x] `ace-test ace-test-runner`
+- [x] Confirm the regression test reports missing package names when the suite inventory is incomplete.
 
 ## Out Of Scope
 - modifying package discovery behavior outside the regression guard

--- a/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/5-recover-ace-git-worktree-fixes/8r9.t.j82.5-recover-ace-git-worktree-fixes-from-fixe2e.s.md
+++ b/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/5-recover-ace-git-worktree-fixes/8r9.t.j82.5-recover-ace-git-worktree-fixes-from-fixe2e.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r9.t.j82.5
-status: pending
+status: done
 priority: medium
 created_at: "2026-04-10 13:01:09"
 estimate: TBD
@@ -39,14 +39,14 @@ needs_review: false
   - directory cleanup never degrades to warning-only continuation
 
 ## Success Criteria
-- [ ] prune command hardening is specified
-- [ ] directory cleanup failure handling is specified
-- [ ] prune and remover regression tests are included
+- [x] prune command hardening is specified
+- [x] directory cleanup failure handling is specified
+- [x] prune and remover regression tests are included
 
 ## Verification Plan
-- [ ] `ace-test ace-git-worktree`
-- [ ] Confirm prune coverage asserts `--expire now`.
-- [ ] Confirm remover coverage fails when the directory still exists after cleanup.
+- [x] `ace-test ace-git-worktree`
+- [x] Confirm prune coverage asserts `--expire now`.
+- [x] Confirm remover coverage fails when the directory still exists after cleanup.
 
 ## Out Of Scope
 - changes to unrelated worktree listing or creation behavior

--- a/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/6-recover-shared-e2e-contract-fixes/8r9.t.j82.6-recover-shared-e2e-role-and-path-contract.s.md
+++ b/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/6-recover-shared-e2e-contract-fixes/8r9.t.j82.6-recover-shared-e2e-role-and-path-contract.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r9.t.j82.6
-status: pending
+status: done
 priority: medium
 created_at: "2026-04-10 13:01:09"
 estimate: TBD
@@ -40,16 +40,16 @@ needs_review: false
   - E2E execution and verification roles remain distinct in shared LLM config
 
 ## Success Criteria
-- [ ] Shared E2E role names are specified as `e2e-runner` and `e2e-verifier`.
-- [ ] Shared discovery paths are specified as `test-e2e/scenarios` and `test-e2e/integration`.
-- [ ] Shared docs and assignment guidance are updated to the same path contract.
-- [ ] Package-local migration work stays out of scope.
+- [x] Shared E2E role names are specified as `e2e-runner` and `e2e-verifier`.
+- [x] Shared discovery paths are specified as `test-e2e/scenarios` and `test-e2e/integration`.
+- [x] Shared docs and assignment guidance are updated to the same path contract.
+- [x] Package-local migration work stays out of scope.
 
 ## Verification Plan
-- [ ] `ace-test ace-assign`
-- [ ] Confirm the bundled shared files no longer refer to package scenarios under `test/e2e`.
-- [ ] Confirm the shared config separates runner and verifier roles instead of using one execution role for both.
-- [ ] Confirm tmux-specific preset deletions remain out of scope.
+- [x] `ace-test ace-assign`
+- [x] Confirm the bundled shared files no longer refer to package scenarios under `test/e2e`.
+- [x] Confirm the shared config separates runner and verifier roles instead of using one execution role for both.
+- [x] Confirm tmux-specific preset deletions remain out of scope.
 
 ## Out Of Scope
 - any package-local scenario content or deterministic test rewrites

--- a/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/8r9.t.j82-migrate-pr-285-package-config-fixes-as.s.md
+++ b/.ace-tasks/_archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/8r9.t.j82-migrate-pr-285-package-config-fixes-as.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r9.t.j82
-status: in-progress
+status: done
 priority: high
 created_at: "2026-04-10 12:48:58"
 estimate: TBD

--- a/.ace/bundle/presets/project.md
+++ b/.ace/bundle/presets/project.md
@@ -2,7 +2,7 @@
 description: Project context
 bundle:
   params:
-    # output: cache
+    output: cache
     max_size: 81920
     timeout: 30
     compressor_mode: agent

--- a/.ace/docs/config.yml
+++ b/.ace/docs/config.yml
@@ -130,4 +130,5 @@ ignore:
   - "**/coverage/**"
   - "**/_legacy/**"
   - "**/.ace-tasks/done/**"
+  - "*/test-e2e/scenarios/**/*.md"
   - "*/test/e2e/**/*.md"

--- a/.ace/e2e-runner/config.yml
+++ b/.ace/e2e-runner/config.yml
@@ -2,13 +2,19 @@
 
 paths:
   # Where test scenarios are stored in packages
-  scenarios: "test/e2e"
+  scenarios: "test-e2e/scenarios"
+  # Legacy fallback kept during migration window (runtime still supports this)
+  scenarios_legacy: "test/e2e"
+  integration: "test-e2e/integration"
   # Directory for test execution artifacts (gitignored)
   cache_dir: ".ace-local/test-e2e"
 
 patterns:
   # Glob pattern for finding test scenarios (TS-format directories)
-  discovery: "test/e2e/TS-*/scenario.yml"
+  discovery: "test-e2e/scenarios/TS-*/scenario.yml"
+  # Legacy fallback kept during migration window (runtime still supports this)
+  discovery_legacy: "test/e2e/TS-*/scenario.yml"
+  integration: "test-e2e/integration/**/*_test.rb"
 
 # Test scenario frontmatter requirements
 required_fields:
@@ -38,7 +44,9 @@ reporting:
 # Execution defaults
 execution:
   # Default LLM provider:model for test execution
-  provider: "role:e2e-executor"
+  provider: "role:e2e-runner"
+  runner_provider: "role:e2e-runner"
+  verifier_provider: "role:e2e-verifier"
   # Timeout per test in seconds
   timeout: 600
   # Number of tests to run in parallel (1 = sequential)

--- a/.ace/llm/config.yml
+++ b/.ace/llm/config.yml
@@ -57,10 +57,14 @@ llm:
       - claude:opus:medium@yolo
 
     # --- E2E testing ---
-    e2e-executor:
-      - codex:mini:low@yolo
+    e2e-runner:
+      - codex:mini:medium@yolo
       - gemini:flash-latest@yolo
       - claude:haiku:low@yolo
+    e2e-verifier:
+      - codex:mini:medium@ro
+      - gemini:flash-latest@ro
+      - claude:haiku:low@ro
     e2e-reporter:
       - codex:mini:low@ro
       - gemini:flash-latest@ro

--- a/.ace/test/suite.yml
+++ b/.ace/test/suite.yml
@@ -35,6 +35,11 @@ test_suite:
       group: tools
       priority: 2
 
+    - name: ace-compressor
+      path: ace-compressor
+      group: tools
+      priority: 2
+
     - name: ace-support-nav
       path: ace-support-nav
       group: tools
@@ -48,6 +53,11 @@ test_suite:
     - name: ace-b36ts
       path: ace-b36ts
       group: foundation
+      priority: 2
+
+    - name: ace-demo
+      path: ace-demo
+      group: tools
       priority: 2
 
     - name: ace-support-items
@@ -84,6 +94,31 @@ test_suite:
       path: ace-docs
       group: tools
       priority: 1
+
+    - name: ace-handbook-integration-claude
+      path: ace-handbook-integration-claude
+      group: tools
+      priority: 2
+
+    - name: ace-handbook-integration-codex
+      path: ace-handbook-integration-codex
+      group: tools
+      priority: 2
+
+    - name: ace-handbook-integration-gemini
+      path: ace-handbook-integration-gemini
+      group: tools
+      priority: 2
+
+    - name: ace-handbook-integration-opencode
+      path: ace-handbook-integration-opencode
+      group: tools
+      priority: 2
+
+    - name: ace-handbook-integration-pi
+      path: ace-handbook-integration-pi
+      group: tools
+      priority: 2
 
     - name: ace-git-worktree
       path: ace-git-worktree
@@ -150,6 +185,16 @@ test_suite:
       group: tools
       priority: 2
 
+    - name: ace-hitl
+      path: ace-hitl
+      group: tools
+      priority: 2
+
+    - name: ace-test
+      path: ace-test
+      group: tools
+      priority: 2
+
     - name: ace-idea
       path: ace-idea
       group: tools
@@ -157,6 +202,16 @@ test_suite:
 
     - name: ace-retro
       path: ace-retro
+      group: tools
+      priority: 2
+
+    - name: ace-test-runner-e2e
+      path: ace-test-runner-e2e
+      group: tools
+      priority: 2
+
+    - name: ace-monorepo-e2e
+      path: ace-monorepo-e2e
       group: tools
       priority: 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **ace-test-runner v0.19.5**: Stopped forcing single-batch suite execution and made suite aggregation prefer live runtime timeout/failure state over stale package summaries.
+- **ace-test-runner-e2e v0.29.11**: Captured invalid-ref `git diff` stderr during affected-package detection so passing runs no longer leak fatal git output.
 - **ace-test-runner-e2e v0.29.9**: Enforced distinct runner/verifier provider threading in pipeline execution/reporting and aligned runtime scenario discovery with the `test-e2e/scenarios` contract (with legacy `test/e2e` fallback).
 - **ace-assign v0.44.5**: Updated verify-E2E guidance and fixture coverage to keep both `test-e2e/scenarios/` and legacy `test/e2e/` paths valid during migration.
 - **ace-docs v0.32.1**: Restored docs ignore coverage for legacy `test/e2e/**/*.md` scenario markdown during the E2E path migration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **ace-test-runner-e2e v0.29.9**: Enforced distinct runner/verifier provider threading in pipeline execution/reporting and aligned runtime scenario discovery with the `test-e2e/scenarios` contract (with legacy `test/e2e` fallback).
+- **ace-assign v0.44.5**: Updated verify-E2E guidance and fixture coverage to keep both `test-e2e/scenarios/` and legacy `test/e2e/` paths valid during migration.
+- **ace-docs v0.32.1**: Restored docs ignore coverage for legacy `test/e2e/**/*.md` scenario markdown during the E2E path migration.
+- **ace-git-worktree v0.19.5**: Hardened worktree cleanup to fail when directories remain after removal, switched prune to `git worktree prune --expire now`, and added regressions for prune args plus stuck-directory failures.
+- **ace-test-runner v0.19.4**: Added a suite-completeness regression guard that fails when `.ace/test/suite.yml` is missing testable packages discovered by `PackageResolver`.
+- **ace-llm v0.32.2**: Preserved full fallback target selectors across provider switches and rebuilt generation options per fallback target instead of reusing stale primary-provider options.
+- **ace-git-commit v0.23.7**: Restored packaged split defaults (`git.split.enabled: true`, `git.split.strategy: config-scope`), documented `--no-split` override guidance, and added regression coverage for the packaged-default contract.
+- **ace-llm-providers-cli v0.27.3**: Restored Codex and Gemini subprocess environment forwarding and switched Gemini runtime path resolution to the direct execution context working directory.
 - **ace-demo v0.24.0**: Added semantic YAML/asciinema demo verification with classified failure reports in `.ace-local/demo/`, and made `ace-demo record` fail closed instead of uploading broken recordings.
 - **ace-assign v0.42.5**: Hardened `wfi://assign/drive` and related handoff docs so `/as-assign-drive` treats intermediate progress as non-terminal and resumes paused assignments with runnable pending work.
 - **ace-assign v0.42.6**: Tightened the assignment-drive contract so waiting on `fork-run` stays inside the live drive loop and subtree completion immediately resumes the parent assignment queue.
@@ -28,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - **ace-demo v0.24.1**: Added fail-closed demo recording verification with clearer failure classification and structured report paths.
 
 ### Changed
+- **ace-test-runner-e2e v0.29.10**: Documented the E2E migration dual-path contract in shared `.ace/e2e-runner/config.yml` by retaining explicit legacy fallback keys alongside `test-e2e/scenarios`.
 - **ace-task v0.33.2**: Updated the live GitHub sync demo tape to assert exported task/issue refs, forbid known sync/runtime errors, and verify final issue closure during recording.
 - **ace-hitl v0.8.1**: Expanded package description wording to explicitly use "human in the loop (HITL)" in `summary`/`description` and aligned CLI-facing docs wording to the explicit terminology.
 - **ace-task v0.31.10**: Updated ACE-linked issue lifecycle guidance to prefer task metadata plus ACE-managed sync over PR footer closure requirements, while retaining PR closure keywords as optional manual guidance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **ace-test-runner v0.19.6**: Restored suite single-batch execution, kept runtime results authoritative over stale summaries, and made subprocess-sensitive unit-directory tests opt into isolation so `ace-test-suite` and `ace-test --run-in-single-batch` both pass again.
 - **ace-test-runner v0.19.5**: Stopped forcing single-batch suite execution and made suite aggregation prefer live runtime timeout/failure state over stale package summaries.
 - **ace-test-runner-e2e v0.29.11**: Captured invalid-ref `git diff` stderr during affected-package detection so passing runs no longer leak fatal git output.
 - **ace-test-runner-e2e v0.29.9**: Enforced distinct runner/verifier provider threading in pipeline execution/reporting and aligned runtime scenario discovery with the `test-e2e/scenarios` contract (with legacy `test/e2e` fallback).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ace-assign
   specs:
-    ace-assign (0.44.3)
+    ace-assign (0.44.5)
       ace-b36ts (~> 0.13)
       ace-llm (~> 0.30)
       ace-support-cli (~> 0.6)
@@ -51,7 +51,7 @@ PATH
 PATH
   remote: ace-docs
   specs:
-    ace-docs (0.32.0)
+    ace-docs (0.32.1)
       ace-b36ts (~> 0.13)
       ace-git (~> 0.19)
       ace-llm (~> 0.30)
@@ -67,7 +67,7 @@ PATH
 PATH
   remote: ace-git-commit
   specs:
-    ace-git-commit (0.23.6)
+    ace-git-commit (0.23.7)
       ace-git (~> 0.19)
       ace-llm (~> 0.30)
       ace-support-cli (~> 0.6)
@@ -88,7 +88,7 @@ PATH
 PATH
   remote: ace-git-worktree
   specs:
-    ace-git-worktree (0.19.4)
+    ace-git-worktree (0.19.5)
       ace-git (~> 0.19)
       ace-support-cli (~> 0.6)
       ace-support-config (~> 0.9)
@@ -178,13 +178,13 @@ PATH
 PATH
   remote: ace-llm-providers-cli
   specs:
-    ace-llm-providers-cli (0.27.2)
+    ace-llm-providers-cli (0.27.3)
       ace-llm (~> 0.30)
 
 PATH
   remote: ace-llm
   specs:
-    ace-llm (0.32.1)
+    ace-llm (0.32.2)
       ace-support-cli (~> 0.6)
       ace-support-config (~> 0.9)
       ace-support-core (~> 0.29)
@@ -347,7 +347,7 @@ PATH
 PATH
   remote: ace-test-runner-e2e
   specs:
-    ace-test-runner-e2e (0.29.8)
+    ace-test-runner-e2e (0.29.10)
       ace-b36ts (~> 0.13)
       ace-llm (~> 0.30)
       ace-support-cli (~> 0.6)
@@ -357,7 +357,7 @@ PATH
 PATH
   remote: ace-test-runner
   specs:
-    ace-test-runner (0.19.3)
+    ace-test-runner (0.19.4)
       ace-b36ts (~> 0.13)
       ace-support-cli (~> 0.6)
       ace-support-config (~> 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,7 @@ PATH
 PATH
   remote: ace-test-runner-e2e
   specs:
-    ace-test-runner-e2e (0.29.10)
+    ace-test-runner-e2e (0.29.11)
       ace-b36ts (~> 0.13)
       ace-llm (~> 0.30)
       ace-support-cli (~> 0.6)
@@ -357,7 +357,7 @@ PATH
 PATH
   remote: ace-test-runner
   specs:
-    ace-test-runner (0.19.4)
+    ace-test-runner (0.19.5)
       ace-b36ts (~> 0.13)
       ace-support-cli (~> 0.6)
       ace-support-config (~> 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ PATH
 PATH
   remote: ace-test-runner
   specs:
-    ace-test-runner (0.19.5)
+    ace-test-runner (0.19.6)
       ace-b36ts (~> 0.13)
       ace-support-cli (~> 0.6)
       ace-support-config (~> 0.9)

--- a/ace-assign/.ace-defaults/assign/presets/work-on-task.yml
+++ b/ace-assign/.ace-defaults/assign/presets/work-on-task.yml
@@ -34,13 +34,13 @@ steps:
     instructions:
       - "Run E2E tests for packages modified across batch tasks: {{taskrefs}}."
       - "Detect modified packages from the current diff: `git diff origin/main --name-only | grep '^ace-' | cut -d/ -f1 | sort -u`."
-      - "Run `ace-test-e2e <package>` for each modified package that has test/e2e/ scenarios."
+      - "Run `ace-test-e2e <package>` for each modified package that has `test-e2e/scenarios/` scenarios (or legacy `test/e2e/` scenarios during migration)."
       - "If more than 5 packages were modified with cross-dependencies, run the full suite: `ace-test-e2e-suite`."
       - "If any scenarios fail, use /as-e2e-fix to diagnose and fix each failing scenario."
       - "After fixing, rerun the failing scenarios to confirm they pass."
       - "Repeat fix→rerun cycle up to 3 times if new failures appear."
       - "Final gate: all previously-failing scenarios must pass before completing this step."
-      - "Skip only when no modified package has test/e2e/ scenarios."
+      - "Skip only when no modified package has either `test-e2e/scenarios/` or legacy `test/e2e/` scenarios."
 
   - name: release-minor
     number: "020"

--- a/ace-assign/CHANGELOG.md
+++ b/ace-assign/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.5] - 2026-04-10
+
+### Fixed
+- Updated verify-E2E guidance to support both `test-e2e/scenarios/` and legacy `test/e2e/` paths during migration in assignment presets and runtime executor output.
+- Synced the work-on-task E2E fixture contract with the dual-path migration guidance.
+
 ## [0.44.3] - 2026-04-07
 
 ### Fixed

--- a/ace-assign/lib/ace/assign/organisms/assignment_executor.rb
+++ b/ace-assign/lib/ace/assign/organisms/assignment_executor.rb
@@ -853,7 +853,7 @@ module Ace
           when "verify-e2e"
             "- Check change scope: run `git diff origin/main --name-only` to list modified files.\n" \
             "- **Skip criteria**: If ALL modified files match `*.md`, `*.yml` (non-CI config), `.ace-tasks/**`, or `.ace-retros/**`, skip E2E verification — mark step done with \"skipped: docs/task-spec only changes, no runnable code affected\".\n" \
-            "- Otherwise: detect modified packages, run E2E scenarios for each package with `test/e2e/` scenarios#{task_hint}.\n" \
+            "- Otherwise: detect modified packages, run E2E scenarios for each package with `test-e2e/scenarios/` scenarios (or legacy `test/e2e/` scenarios during migration)#{task_hint}.\n" \
             "- If no modified package has E2E scenarios, mark step done with \"skipped: no E2E scenarios for modified packages\"."
           else
             "- Execute the #{sub_name} step."

--- a/ace-assign/lib/ace/assign/version.rb
+++ b/ace-assign/lib/ace/assign/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Assign
-    VERSION = "0.44.3"
+    VERSION = "0.44.5"
   end
 end

--- a/ace-assign/test/e2e/TS-ASSIGN-001-core-workflow/fixtures/prepare/work-on-task.yml
+++ b/ace-assign/test/e2e/TS-ASSIGN-001-core-workflow/fixtures/prepare/work-on-task.yml
@@ -34,13 +34,13 @@ steps:
     instructions:
       - "Run E2E tests for packages modified across batch tasks: {{taskrefs}}."
       - "Detect modified packages from the current diff: `git diff origin/main --name-only | grep '^ace-' | cut -d/ -f1 | sort -u`."
-      - "Run `ace-test-e2e <package>` for each modified package that has test/e2e/ scenarios."
+      - "Run `ace-test-e2e <package>` for each modified package that has `test-e2e/scenarios/` scenarios (or legacy `test/e2e/` scenarios during migration)."
       - "If more than 5 packages were modified with cross-dependencies, run the full suite: `ace-test-e2e-suite`."
       - "If any scenarios fail, use /as-e2e-fix to diagnose and fix each failing scenario."
       - "After fixing, rerun the failing scenarios to confirm they pass."
       - "Repeat fix→rerun cycle up to 3 times if new failures appear."
       - "Final gate: all previously-failing scenarios must pass before completing this step."
-      - "Skip only when no modified package has test/e2e/ scenarios."
+      - "Skip only when no modified package has either `test-e2e/scenarios/` or legacy `test/e2e/` scenarios."
 
   - name: release-minor
     number: "020"

--- a/ace-docs/CHANGELOG.md
+++ b/ace-docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.1] - 2026-04-10
+
+### Fixed
+- Restored docs-management ignore coverage for legacy `test/e2e/**/*.md` scenario markdown paths during the E2E path migration.
+
 ## [0.32.0] - 2026-04-01
 
 ### Changed

--- a/ace-docs/lib/ace/docs/version.rb
+++ b/ace-docs/lib/ace/docs/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Docs
-    VERSION = '0.32.0'
+    VERSION = '0.32.1'
   end
 end

--- a/ace-git-commit/.ace-defaults/git/commit.yml
+++ b/ace-git-commit/.ace-defaults/git/commit.yml
@@ -20,3 +20,8 @@ git:
         - ui
         - docs
         - test
+
+  split:
+    enabled: true
+    strategy: config-scope
+    description: Automatically create multiple commits when multiple config scopes are detected; use --no-split to force a single commit.

--- a/ace-git-commit/CHANGELOG.md
+++ b/ace-git-commit/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.7] - 2026-04-10
+
+### Fixed
+- Restored packaged default split configuration (`git.split.enabled: true`, `git.split.strategy: config-scope`) and documented `--no-split` as the explicit single-commit override.
+- Added packaged-default regression coverage in `test/default_config_test.rb` to enforce the split-default contract.
+
 ## [0.23.6] - 2026-03-31
 
 ### Changed

--- a/ace-git-commit/lib/ace/git_commit/version.rb
+++ b/ace-git-commit/lib/ace/git_commit/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module GitCommit
-    VERSION = '0.23.6'
+    VERSION = '0.23.7'
   end
 end

--- a/ace-git-commit/test/default_config_test.rb
+++ b/ace-git-commit/test/default_config_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "yaml"
+
+class GitCommitDefaultConfigTest < TestCase
+  def test_packaged_defaults_make_auto_split_explicit
+    defaults_path = File.expand_path("../.ace-defaults/git/commit.yml", __dir__)
+    config = YAML.safe_load_file(defaults_path)
+
+    assert_equal true, config.dig("git", "split", "enabled")
+    assert_equal "config-scope", config.dig("git", "split", "strategy")
+    assert_match(/--no-split/, config.dig("git", "split", "description"))
+  end
+end

--- a/ace-git-worktree/CHANGELOG.md
+++ b/ace-git-worktree/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.5] - 2026-04-10
+
+### Fixed
+- Hardened `WorktreeRemover` cleanup semantics to fail when the worktree directory still exists after cleanup, including explicit error results on removal exceptions.
+- Updated prune execution to run `git worktree prune --expire now` for immediate stale-metadata cleanup.
+
+### Technical
+- Added regression coverage asserting `--expire now` prune args and stuck-directory failure behavior in worktree remover tests.
+
 ## [0.19.4] - 2026-03-29
 
 ### Technical

--- a/ace-git-worktree/lib/ace/git/worktree/molecules/worktree_remover.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/molecules/worktree_remover.rb
@@ -84,7 +84,8 @@ module Ace
 
               # Optionally remove the directory
               if remove_directory && File.exist?(expanded_path)
-                remove_worktree_directory(expanded_path)
+                directory_result = remove_worktree_directory(expanded_path)
+                return directory_result unless directory_result[:success]
               end
 
               # Optionally delete the branch
@@ -305,11 +306,14 @@ module Ace
           #
           # @param worktree_path [String] Worktree path
           def remove_worktree_directory(worktree_path)
-            if File.exist?(worktree_path)
-              FileUtils.rm_rf(worktree_path)
-            end
+            return {success: true, message: "Worktree directory already absent"} unless File.exist?(worktree_path)
+
+            FileUtils.rm_rf(worktree_path)
+            return {success: true, message: "Worktree directory removed"} unless File.exist?(worktree_path)
+
+            error_result("Worktree directory still exists after removal: #{worktree_path}")
           rescue => e
-            warn "Warning: Failed to remove worktree directory: #{e.message}"
+            error_result("Failed to remove worktree directory: #{e.message}")
           end
 
           # Check if worktree has uncommitted changes
@@ -339,7 +343,7 @@ module Ace
           # @return [Hash] Command result
           def execute_git_worktree_prune
             require_relative "../atoms/git_command"
-            Atoms::GitCommand.worktree("prune", timeout: @timeout)
+            Atoms::GitCommand.worktree("prune", "--expire", "now", timeout: @timeout)
           end
 
           # Parse prune output to count pruned worktrees

--- a/ace-git-worktree/lib/ace/git/worktree/version.rb
+++ b/ace-git-worktree/lib/ace/git/worktree/version.rb
@@ -3,7 +3,7 @@
 module Ace
   module Git
     module Worktree
-      VERSION = '0.19.4'
+      VERSION = '0.19.5'
     end
   end
 end

--- a/ace-git-worktree/test/commands/prune_command_test.rb
+++ b/ace-git-worktree/test/commands/prune_command_test.rb
@@ -29,6 +29,21 @@ class PruneCommandTest < Minitest::Test
     mock_worktree_manager.verify
   end
 
+  def test_prune_command_uses_expire_now_in_remover
+    remover = Ace::Git::Worktree::Molecules::WorktreeRemover.new
+    calls = []
+
+    Ace::Git::Worktree::Atoms::GitCommand.stub(:worktree, lambda { |*args, **kwargs|
+      calls << [args, kwargs]
+      {success: true, output: "", error: nil}
+    }) do
+      result = remover.prune
+      assert result[:success]
+    end
+
+    assert_equal [["prune", "--expire", "now"], {timeout: Ace::Git::Worktree.remove_timeout}], calls.first
+  end
+
   def test_run_with_dry_run_flag
     # Mock successful dry run pruning
     mock_worktree_manager = Minitest::Mock.new

--- a/ace-git-worktree/test/molecules/worktree_remover_test.rb
+++ b/ace-git-worktree/test/molecules/worktree_remover_test.rb
@@ -208,6 +208,28 @@ class WorktreeRemoverTest < Minitest::Test
     end
   end
 
+  def test_remove_fails_when_directory_still_exists_after_cleanup
+    worktree_path = File.join(@temp_dir, ".ace-wt", "stuck-branch")
+    branch_name = "stuck-branch"
+
+    FileUtils.mkdir_p(worktree_path)
+    worktree_info = mock_worktree_info(worktree_path, branch_name)
+
+    @remover.stub(:find_worktree_info, worktree_info) do
+      @remover.stub(:has_uncommitted_changes?, false) do
+        git_result = {success: true, output: "", error: nil}
+        Ace::Git::Worktree::Atoms::GitCommand.stub(:worktree, git_result) do
+          FileUtils.stub(:rm_rf, nil) do
+            result = @remover.remove(worktree_path)
+
+            refute result[:success]
+            assert_match(/still exists after removal/, result[:error])
+          end
+        end
+      end
+    end
+  end
+
   def test_delete_branch_if_safe_with_merged_branch
     branch_name = "merged-feature"
 

--- a/ace-handbook/docs/release-rubygems-proof.md
+++ b/ace-handbook/docs/release-rubygems-proof.md
@@ -3,8 +3,8 @@ doc-type: user
 title: RubyGems Propagation Proof Contract
 purpose: Define deterministic post-release proof for dependency metadata propagation
 ace-docs:
-  last-updated: 2026-03-29
-  last-checked: 2026-03-29
+  last-updated: '2026-04-10'
+  last-checked: '2026-04-10'
 ---
 
 # RubyGems Propagation Proof Contract
@@ -22,7 +22,7 @@ This contract does not claim to fix RubyGems propagation behavior. It proves whe
 ## Scope
 
 - Applies to many-package ACE releases.
-- Runs after publish succeeds, via `ace-test-e2e ace-monorepo-e2e --test-id TS-MONO-001`.
+- Runs after publish succeeds, via `ace-test-e2e ace-monorepo-e2e TS-MONO-001`.
 - Produces one artifact consumed by release and onboarding docs workflows.
 
 ## Proof Commands

--- a/ace-handbook/docs/usage.md
+++ b/ace-handbook/docs/usage.md
@@ -3,8 +3,8 @@ doc-type: user
 title: Ace::Handbook Usage Reference
 purpose: Practical command reference for ace-handbook workflows
 ace-docs:
-  last-updated: 2026-03-29
-  last-checked: 2026-03-29
+  last-updated: '2026-04-10'
+  last-checked: '2026-04-10'
 ---
 
 # ace-handbook Usage Reference
@@ -113,5 +113,5 @@ ace-handbook sync
 - Keep command invocations direct (`ace-*`) without shell post-processing.
 - Treat loaded workflow bundles as canonical instructions.
 - Keep README concise and move detailed reference content into `ace-handbook/docs/`.
-- For multi-package releases, use `wfi://release/rubygems-publish` to publish, then run `ace-test-e2e ace-monorepo-e2e --test-id TS-MONO-001` to record the propagation proof result (`SAFE`, `LAG_DETECTED`, or `METADATA_BROKEN`) with mitigation guidance when lag is detected.
+- For multi-package releases, use `wfi://release/rubygems-publish` to publish, then run `ace-test-e2e ace-monorepo-e2e TS-MONO-001` to record the propagation proof result (`SAFE`, `LAG_DETECTED`, or `METADATA_BROKEN`) with mitigation guidance when lag is detected.
 - See `ace-handbook/docs/release-rubygems-proof.md` for the proof contract consumed by onboarding docs.

--- a/ace-handbook/handbook/cookbooks/setup-starting-a-multi-ruby-gem-monorepo-with-ace.cookbook.md
+++ b/ace-handbook/handbook/cookbooks/setup-starting-a-multi-ruby-gem-monorepo-with-ace.cookbook.md
@@ -1,7 +1,7 @@
 # Setup Cookbook: Starting a Multi Ruby Gem Monorepo with ACE
 
 **Created**: 2026-04-01
-**Last Updated**: 2026-04-01
+**Last Updated**: 2026-04-10
 **Category**: setup
 **Audience**: intermediate
 **Estimated Time**: 2-4 hours
@@ -21,8 +21,8 @@ This cookbook distills monorepo setup patterns from ACE package conventions and 
   - `ace-monorepo-e2e/README.md`
   - `.ace-retros/8quwjc-monorepo-e2e-quickstart-verification/8quwjc-monorepo-e2e-quickstart-verification.retro.md`
 - Validation evidence (commands, reports, or artifacts):
-  - `ace-test-e2e ace-monorepo-e2e --test-id TS-MONO-001`
-  - `ace-test-e2e ace-monorepo-e2e --test-id TS-MONO-002`
+  - `ace-test-e2e ace-monorepo-e2e TS-MONO-001`
+  - `ace-test-e2e ace-monorepo-e2e TS-MONO-002`
   - `ace-nav resolve cookbook://setup-starting-a-multi-ruby-gem-monorepo-with-ace`
 - Last source verification date: 2026-04-01
 
@@ -98,8 +98,8 @@ ace-test-e2e ace-monorepo-e2e
 **Commands/Actions:**
 
 ```bash
-ace-test-e2e ace-monorepo-e2e --test-id TS-MONO-001
-ace-test-e2e ace-monorepo-e2e --test-id TS-MONO-002
+ace-test-e2e ace-monorepo-e2e TS-MONO-001
+ace-test-e2e ace-monorepo-e2e TS-MONO-002
 ```
 
 If runs are network-heavy, raise timeout budgets deliberately and record the reason in scenario docs.

--- a/ace-handbook/handbook/skills/as-release-rubygems-publish/SKILL.md
+++ b/ace-handbook/handbook/skills/as-release-rubygems-publish/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools:
   - Bash(ace-bundle:*)
   - Read
 argument-hint: "[gem-name...] [--dry-run]"
-last_modified: 2026-03-29
+last_modified: 2026-04-10
 source: ace-handbook
 integration:
   targets:
@@ -47,4 +47,4 @@ None
 - Do the work described by the workflow instead of only summarizing it.
 - When the workflow requires edits, tests, or commits, perform them in this project.
 
-- After live publishing, recommend running `ace-test-e2e ace-monorepo-e2e --test-id TS-MONO-001` for installation verification.
+- After live publishing, recommend running `ace-test-e2e ace-monorepo-e2e TS-MONO-001` for installation verification.

--- a/ace-hitl/test/commands/hitl_cli_test.rb
+++ b/ace-hitl/test/commands/hitl_cli_test.rb
@@ -42,7 +42,7 @@ class HitlCliTest < AceHitlTestCase
   end
 
   def test_library_contract
-    assert_equal "0.8.0", Ace::Hitl::VERSION
+    assert_equal "0.8.1", Ace::Hitl::VERSION
     assert_respond_to Ace::Hitl::HitlCLI, :start
   end
 

--- a/ace-llm-providers-cli/CHANGELOG.md
+++ b/ace-llm-providers-cli/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.3] - 2026-04-10
+
+### Fixed
+- Forwarded `subprocess_env` into Codex and Gemini `SafeCapture` execution.
+- Updated Gemini prompt-cache and subprocess working-dir resolution to use execution context directly.
+
+### Technical
+- Added Codex and Gemini regression coverage to assert `SafeCapture` receives forwarded `env`.
+
 ## [0.27.2] - 2026-03-29
 
 ### Technical

--- a/ace-llm-providers-cli/lib/ace/llm/providers/cli/codex_client.rb
+++ b/ace-llm-providers-cli/lib/ace/llm/providers/cli/codex_client.rb
@@ -206,6 +206,7 @@ module Ace
               timeout: timeout_val,
               stdin_data: input,
               chdir: working_dir,
+              env: options[:subprocess_env],
               provider_name: "Codex"
             )
           end

--- a/ace-llm-providers-cli/lib/ace/llm/providers/cli/gemini_client.rb
+++ b/ace-llm-providers-cli/lib/ace/llm/providers/cli/gemini_client.rb
@@ -245,7 +245,11 @@ module Ace
           end
 
           def create_prompt_cache_dir(working_dir = nil, subprocess_env: nil)
-            cache_dir = File.join(find_project_root(working_dir, subprocess_env: subprocess_env), ".ace-local", "llm", "prompts")
+            resolved_working_dir = Atoms::ExecutionContext.resolve_working_dir(
+              working_dir: working_dir,
+              subprocess_env: subprocess_env
+            )
+            cache_dir = File.join(resolved_working_dir, ".ace-local", "llm", "prompts")
             FileUtils.mkdir_p(cache_dir) unless Dir.exist?(cache_dir)
             cache_dir
           end
@@ -256,17 +260,17 @@ module Ace
 
           def execute_gemini_command(cmd, prompt, options)
             timeout_val = options[:timeout] || @options[:timeout] || 120
-            project_root = find_project_root(options[:working_dir], subprocess_env: options[:subprocess_env])
-            Molecules::SafeCapture.call(cmd, timeout: timeout_val, chdir: project_root, provider_name: "Gemini")
-          end
-
-          def find_project_root(working_dir = nil, subprocess_env: nil)
-            require "ace/support/fs"
-            start_path = Atoms::ExecutionContext.resolve_working_dir(
-              working_dir: working_dir,
-              subprocess_env: subprocess_env
+            working_dir = Atoms::ExecutionContext.resolve_working_dir(
+              working_dir: options[:working_dir],
+              subprocess_env: options[:subprocess_env]
             )
-            Ace::Support::Fs::Molecules::ProjectRootFinder.find(start_path: start_path) || start_path
+            Molecules::SafeCapture.call(
+              cmd,
+              timeout: timeout_val,
+              chdir: working_dir,
+              env: options[:subprocess_env],
+              provider_name: "Gemini"
+            )
           end
 
           def parse_gemini_response(stdout, stderr, status, prompt, options)

--- a/ace-llm-providers-cli/lib/ace/llm/providers/cli/version.rb
+++ b/ace-llm-providers-cli/lib/ace/llm/providers/cli/version.rb
@@ -4,7 +4,7 @@ module Ace
   module LLM
     module Providers
       module CLI
-        VERSION = '0.27.2'
+        VERSION = '0.27.3'
       end
     end
   end

--- a/ace-llm-providers-cli/test/molecules/codex_client_test.rb
+++ b/ace-llm-providers-cli/test/molecules/codex_client_test.rb
@@ -248,6 +248,28 @@ describe "CodexClient" do
 
       assert_equal "/tmp/e2e-sandbox", captured_kwargs[:chdir]
     end
+
+    it "passes subprocess_env to SafeCapture env" do
+      captured_kwargs = nil
+      mock_status = Object.new
+      mock_status.define_singleton_method(:success?) { true }
+      mock_status.define_singleton_method(:exitstatus) { 0 }
+
+      @client.stub(:codex_available?, true) do
+        @client.stub(:codex_authenticated?, true) do
+          @client.stub(:resolve_skills_dir, nil) do
+            Ace::LLM::Providers::CLI::Molecules::SafeCapture.stub(:call, lambda { |*_args, **kwargs|
+              captured_kwargs = kwargs
+              ["codex\nok\n", "", mock_status]
+            }) do
+              @client.generate("Hi", subprocess_env: {"PROJECT_ROOT_PATH" => "/tmp/e2e-sandbox"})
+            end
+          end
+        end
+      end
+
+      assert_equal({"PROJECT_ROOT_PATH" => "/tmp/e2e-sandbox"}, captured_kwargs[:env])
+    end
   end
 
   describe "skill command rewriting" do

--- a/ace-llm-providers-cli/test/molecules/gemini_client_test.rb
+++ b/ace-llm-providers-cli/test/molecules/gemini_client_test.rb
@@ -264,6 +264,24 @@ describe "GeminiClient" do
       assert_equal "/tmp/e2e-sandbox", captured_kwargs[:chdir]
     end
 
+    it "passes subprocess_env to SafeCapture env" do
+      captured_kwargs = nil
+      mock_status = Object.new
+      mock_status.define_singleton_method(:success?) { true }
+      mock_status.define_singleton_method(:exitstatus) { 0 }
+
+      @client.stub(:gemini_available?, true) do
+        Ace::LLM::Providers::CLI::Molecules::SafeCapture.stub(:call, lambda { |*_args, **kwargs|
+          captured_kwargs = kwargs
+          ['{"response":"ok"}', "", mock_status]
+        }) do
+          @client.generate("Hi", subprocess_env: {"PROJECT_ROOT_PATH" => "/tmp/e2e-sandbox"})
+        end
+      end
+
+      assert_equal({"PROJECT_ROOT_PATH" => "/tmp/e2e-sandbox"}, captured_kwargs[:env])
+    end
+
     it "builds command with pre-existing files when system_file and prompt_file provided" do
       # Test the code path used by ace-review to avoid double-writing files
       cmd = @client.send(:build_gemini_command, "ignored prompt", {

--- a/ace-llm/CHANGELOG.md
+++ b/ace-llm/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Preserved full fallback target selectors (including provider/model + suffix context) across fallback attempts and rebuilt generation options per target instead of reusing stale primary-provider options.
+
 ## [0.32.1] - 2026-04-01
 
 ### Fixed

--- a/ace-llm/lib/ace/llm/molecules/fallback_orchestrator.rb
+++ b/ace-llm/lib/ace/llm/molecules/fallback_orchestrator.rb
@@ -2,6 +2,7 @@
 
 require_relative "../atoms/error_classifier"
 require_relative "../models/fallback_config"
+require_relative "provider_model_parser"
 
 module Ace
   module LLM
@@ -35,10 +36,12 @@ module Ace
           @visited_providers.clear
 
           # If fallback disabled, just execute with primary
-          return yield get_client(primary_provider, registry) if @config.disabled?
+          return yield(get_client(primary_provider, registry), primary_provider) if @config.disabled?
 
           # Try primary provider with retries
-          result = try_provider_with_retry(primary_provider, registry) { |client| yield client }
+          result = try_provider_with_retry(primary_provider, registry) do |client, provider_name|
+            yield client, provider_name
+          end
           return result if result
 
           # Try fallback providers in order (per-provider chain or default)
@@ -54,7 +57,9 @@ module Ace
 
             report_status("ℹ Trying fallback provider #{fallback_provider}...")
 
-            result = try_provider_with_retry(fallback_provider, registry) { |client| yield client }
+            result = try_provider_with_retry(fallback_provider, registry) do |client, provider_name|
+              yield client, provider_name
+            end
             return result if result
           end
 
@@ -77,7 +82,7 @@ module Ace
 
           loop do
             client = get_client(provider_name, registry)
-            return yield client
+            return yield client, provider_name
           rescue => error
             last_error = error
 
@@ -145,10 +150,11 @@ module Ace
           opts = {}
           opts[:timeout] = @timeout if @timeout
 
-          # Parse provider:model format if present
-          if provider_name.include?(":")
-            provider, model = provider_name.split(":", 2)
-            registry.get_client(provider, model: model, **opts)
+          parser = ProviderModelParser.new(registry: registry)
+          parsed = parser.parse(provider_name.to_s)
+
+          if parsed.valid?
+            registry.get_client(parsed.provider, model: parsed.model, **opts)
           else
             registry.get_client(provider_name, **opts)
           end

--- a/ace-llm/lib/ace/llm/query_interface.rb
+++ b/ace-llm/lib/ace/llm/query_interface.rb
@@ -43,12 +43,6 @@ module Ace
         raise Error, parse_result.error unless parse_result.valid?
 
         resolved_preset = resolve_preset_name(parse_result.preset, preset)
-        execution_overrides = load_execution_overrides(
-          provider: parse_result.provider,
-          preset: resolved_preset,
-          thinking_level: parse_result.thinking_level
-        )
-
         final_model = model || parse_result.model
         if final_model.nil? || final_model.empty?
           raise Error, "No model specified and no default available for #{parse_result.provider}"
@@ -63,38 +57,40 @@ module Ace
         messages << {role: "system", content: system} if system && !system.empty?
         messages << {role: "user", content: final_prompt}
 
-        generation_opts = {}
-        resolved_temperature = first_non_nil(temperature, execution_overrides["temperature"])
-        resolved_max_tokens = first_non_nil(max_tokens, execution_overrides["max_tokens"])
-        resolved_cli_args = first_non_nil(cli_args, execution_overrides["cli_args"])
-        resolved_system_append = first_non_empty(system_append, execution_overrides["system_append"])
-        resolved_sandbox = first_non_nil(sandbox, execution_overrides["sandbox"])
-        resolved_working_dir = first_non_nil(working_dir, execution_overrides["working_dir"])
-        resolved_subprocess_env = merge_hash_values(execution_overrides["subprocess_env"], subprocess_env)
-
-        generation_opts[:temperature] = resolved_temperature unless resolved_temperature.nil?
-        generation_opts[:max_tokens] = resolved_max_tokens unless resolved_max_tokens.nil?
-        generation_opts[:system_file] = system_file if system_file
-        generation_opts[:prompt_file] = prompt_file if prompt_file
-        generation_opts[:cli_args] = resolved_cli_args unless blank_value?(resolved_cli_args)
-        generation_opts[:system_append] = resolved_system_append unless blank_value?(resolved_system_append)
-        generation_opts[:sandbox] = resolved_sandbox if resolved_sandbox
-        generation_opts[:working_dir] = resolved_working_dir unless blank_value?(resolved_working_dir)
-        generation_opts[:subprocess_env] = resolved_subprocess_env unless resolved_subprocess_env.nil?
-        generation_opts[:last_message_file] = last_message_file if last_message_file
+        generation_opts = build_generation_opts(
+          provider: parse_result.provider,
+          preset: resolved_preset,
+          thinking_level: parse_result.thinking_level,
+          temperature: temperature,
+          max_tokens: max_tokens,
+          system_file: system_file,
+          prompt_file: prompt_file,
+          cli_args: cli_args,
+          system_append: system_append,
+          sandbox: sandbox,
+          working_dir: working_dir,
+          subprocess_env: subprocess_env,
+          last_message_file: last_message_file
+        )
+        execution_overrides = load_execution_overrides(
+          provider: parse_result.provider,
+          preset: resolved_preset,
+          thinking_level: parse_result.thinking_level
+        )
 
         if debug
           warn "Provider: #{parse_result.provider}"
           warn "Model: #{final_model}"
           warn "Preset: #{resolved_preset}" if resolved_preset
           warn "Thinking level: #{parse_result.thinking_level}" if parse_result.thinking_level
-          warn "Temperature: #{resolved_temperature}" unless resolved_temperature.nil?
-          warn "Max tokens: #{resolved_max_tokens}" unless resolved_max_tokens.nil?
+          warn "Temperature: #{generation_opts[:temperature]}" unless generation_opts[:temperature].nil?
+          warn "Max tokens: #{generation_opts[:max_tokens]}" unless generation_opts[:max_tokens].nil?
         end
 
         fallback_config = load_fallback_config(fallback, fallback_providers, parser: parser)
         timeout_value = first_non_nil(timeout, execution_overrides["timeout"], Molecules::ConfigLoader.get("llm.timeout"), 120)
         resolved_timeout = normalize_timeout(timeout_value)
+        parser_for_options = Molecules::ProviderModelParser.new(registry: registry)
 
         response = execute_with_fallback(
           provider: parse_result.provider,
@@ -105,7 +101,38 @@ module Ace
           fallback_config: fallback_config,
           timeout: resolved_timeout,
           debug: debug,
-          role_fallbacks: parse_result.role_fallbacks
+          role_fallbacks: parse_result.role_fallbacks,
+          preset: resolved_preset,
+          thinking_level: parse_result.thinking_level,
+          option_builder: lambda { |target_selector|
+            parsed_target = parser_for_options.parse(target_selector.to_s)
+            target_provider = parsed_target.valid? ? parsed_target.provider : parse_result.provider
+            target_preset = if parsed_target.valid? && parsed_target.preset
+              parsed_target.preset
+            else
+              resolved_preset
+            end
+            target_thinking = if parsed_target.valid?
+              parsed_target.thinking_level
+            else
+              parse_result.thinking_level
+            end
+            build_generation_opts(
+              provider: target_provider,
+              preset: target_preset,
+              thinking_level: target_thinking,
+              temperature: temperature,
+              max_tokens: max_tokens,
+              system_file: system_file,
+              prompt_file: prompt_file,
+              cli_args: cli_args,
+              system_append: system_append,
+              sandbox: sandbox,
+              working_dir: working_dir,
+              subprocess_env: subprocess_env,
+              last_message_file: last_message_file
+            )
+          }
         )
 
         text_content = extract_text_content(response)
@@ -173,6 +200,37 @@ module Ace
         merged
       end
       private_class_method :load_execution_overrides
+
+      def self.build_generation_opts(provider:, preset:, thinking_level:, temperature:, max_tokens:, system_file:,
+        prompt_file:, cli_args:, system_append:, sandbox:, working_dir:, subprocess_env:, last_message_file:)
+        execution_overrides = load_execution_overrides(
+          provider: provider,
+          preset: preset,
+          thinking_level: thinking_level
+        )
+
+        generation_opts = {}
+        resolved_temperature = first_non_nil(temperature, execution_overrides["temperature"])
+        resolved_max_tokens = first_non_nil(max_tokens, execution_overrides["max_tokens"])
+        resolved_cli_args = first_non_nil(cli_args, execution_overrides["cli_args"])
+        resolved_system_append = first_non_empty(system_append, execution_overrides["system_append"])
+        resolved_sandbox = first_non_nil(sandbox, execution_overrides["sandbox"])
+        resolved_working_dir = first_non_nil(working_dir, execution_overrides["working_dir"])
+        resolved_subprocess_env = merge_hash_values(execution_overrides["subprocess_env"], subprocess_env)
+
+        generation_opts[:temperature] = resolved_temperature unless resolved_temperature.nil?
+        generation_opts[:max_tokens] = resolved_max_tokens unless resolved_max_tokens.nil?
+        generation_opts[:system_file] = system_file if system_file
+        generation_opts[:prompt_file] = prompt_file if prompt_file
+        generation_opts[:cli_args] = resolved_cli_args unless blank_value?(resolved_cli_args)
+        generation_opts[:system_append] = resolved_system_append unless blank_value?(resolved_system_append)
+        generation_opts[:sandbox] = resolved_sandbox if resolved_sandbox
+        generation_opts[:working_dir] = resolved_working_dir unless blank_value?(resolved_working_dir)
+        generation_opts[:subprocess_env] = resolved_subprocess_env unless resolved_subprocess_env.nil?
+        generation_opts[:last_message_file] = last_message_file if last_message_file
+        generation_opts
+      end
+      private_class_method :build_generation_opts
 
       def self.merge_execution_overrides(base, overlay)
         left = base.respond_to?(:to_h) ? deep_stringify_keys(base.to_h) : deep_stringify_keys(base || {})
@@ -291,7 +349,7 @@ module Ace
       end
 
       def self.execute_with_fallback(provider:, model:, messages:, generation_opts:,
-        registry:, fallback_config:, timeout:, debug:, role_fallbacks: nil)
+        registry:, fallback_config:, timeout:, debug:, role_fallbacks: nil, preset: nil, thinking_level: nil, option_builder:)
         if fallback_config.disabled?
           client = registry.get_client(provider, model: model, timeout: timeout)
           return client.generate(messages, **generation_opts)
@@ -300,9 +358,10 @@ module Ace
         primary_provider_string = model ? "#{provider}:#{model}" : provider
 
         # Inject remaining role candidates ahead of the global fallback chain
+        normalized_role_fallbacks = normalize_fallback_providers(role_fallbacks, Molecules::ProviderModelParser.new(registry: registry))
         if role_fallbacks&.any?
           existing_chain = fallback_config.providers_for(primary_provider_string)
-          merged_chain = role_fallbacks + (existing_chain - role_fallbacks)
+          merged_chain = normalized_role_fallbacks + (existing_chain - normalized_role_fallbacks)
           fallback_config = fallback_config.merge(chains: {primary_provider_string => merged_chain})
         end
 
@@ -314,8 +373,13 @@ module Ace
           timeout: timeout
         )
 
-        orchestrator.execute(primary_provider: primary_provider_string, registry: registry) do |client|
-          client.generate(messages, **generation_opts)
+        orchestrator.execute(primary_provider: primary_provider_string, registry: registry) do |client, target_selector|
+          opts = if target_selector.to_s == primary_provider_string
+            generation_opts
+          else
+            option_builder.call(target_selector)
+          end
+          client.generate(messages, **opts)
         end
       end
 
@@ -380,7 +444,7 @@ module Ace
 
           parse_result = parser.parse(provider)
           canonical_provider = if parse_result.valid?
-            "#{parse_result.provider}:#{parse_result.model}"
+            parse_result.to_s
           else
             provider
           end

--- a/ace-llm/lib/ace/llm/version.rb
+++ b/ace-llm/lib/ace/llm/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module LLM
-    VERSION = '0.32.1'
+    VERSION = '0.32.2'
   end
 end

--- a/ace-llm/test/integration/query_interface_fallback_test.rb
+++ b/ace-llm/test/integration/query_interface_fallback_test.rb
@@ -210,11 +210,105 @@ module Ace
         assert_equal ["google:gemini-2.0-flash-lite", "openai:gpt-5"], config.providers
       end
 
+      def test_execute_with_fallback_rebuilds_provider_specific_generation_opts
+        codex_client = FakeClient.new
+        gemini_client = FakeClient.new
+        registry = FakeFallbackRegistry.new(
+          "codex" => codex_client,
+          "gemini" => gemini_client
+        )
+        fallback_config = Models::FallbackConfig.new(
+          enabled: true,
+          providers: ["gemini:gemini-2.5-flash"]
+        )
+
+        codex_client.define_singleton_method(:generate) do |_messages, **_options|
+          raise Ace::LLM::ProviderError, "codex failed"
+        end
+
+        gemini_client.define_singleton_method(:generate) do |_messages, **options|
+          self.received_options = options
+          {text: "ok", metadata: {}}
+        end
+
+        result = QueryInterface.send(
+          :execute_with_fallback,
+          provider: "codex",
+          model: "gpt-5.4-mini",
+          messages: [{role: "user", content: "hi"}],
+          generation_opts: {},
+          registry: registry,
+          fallback_config: fallback_config,
+          timeout: 60,
+          debug: false,
+          role_fallbacks: nil,
+          preset: "ro",
+          thinking_level: nil,
+          option_builder: lambda { |attempt_provider|
+            {cli_args: ["--#{attempt_provider}-only"]}
+          }
+        )
+
+        assert_equal "ok", result[:text]
+        assert_equal ["--gemini:gemini-2.5-flash-only"], gemini_client.received_options[:cli_args]
+      end
+
+      def test_execute_with_fallback_preserves_per_target_role_suffixes
+        claude_client = FakeClient.new
+        gemini_client = FakeClient.new
+        registry = FakeFallbackRegistry.new(
+          "claude" => claude_client,
+          "gemini" => gemini_client
+        )
+        fallback_config = Models::FallbackConfig.new(
+          enabled: true,
+          chains: {
+            "claude:claude-haiku-4-5" => ["gemini:gemini-3-flash-preview@ro"]
+          }
+        )
+
+        claude_client.define_singleton_method(:generate) do |_messages, **_options|
+          raise Ace::LLM::ProviderError, "claude failed"
+        end
+
+        gemini_client.define_singleton_method(:generate) do |_messages, **options|
+          self.received_options = options
+          {text: "ok", metadata: {}}
+        end
+
+        result = QueryInterface.send(
+          :execute_with_fallback,
+          provider: "claude",
+          model: "claude-haiku-4-5",
+          messages: [{role: "user", content: "hi"}],
+          generation_opts: {cli_args: ["--claude-only"]},
+          registry: registry,
+          fallback_config: fallback_config,
+          timeout: 60,
+          debug: false,
+          role_fallbacks: ["gemini:gemini-3-flash-preview@ro"],
+          preset: "ro",
+          thinking_level: "low",
+          option_builder: lambda { |target_selector|
+            {cli_args: ["target=#{target_selector}"]}
+          }
+        )
+
+        assert_equal "ok", result[:text]
+        assert_equal ["target=gemini:gemini-3-flash-preview@ro"], gemini_client.received_options[:cli_args]
+      end
+
       private
+
+      FakeClient = Struct.new(:received_options)
 
       FakeParseResult = Struct.new(:provider, :model, :valid) do
         def valid?
           valid
+        end
+
+        def to_s
+          "#{provider}:#{model}"
         end
       end
 
@@ -225,6 +319,37 @@ module Ace
 
         def parse(input)
           @results.fetch(input.to_s.strip, FakeParseResult.new(nil, nil, false))
+        end
+      end
+
+      class FakeFallbackRegistry
+        def initialize(clients)
+          @clients = clients
+        end
+
+        def available_providers
+          @clients.keys
+        end
+
+        def models_for_provider(provider)
+          case provider
+          when "codex"
+            ["gpt-5.4-mini"]
+          when "gemini"
+            ["gemini-2.5-flash", "gemini-3-flash-preview"]
+          when "claude"
+            ["claude-haiku-4-5"]
+          else
+            []
+          end
+        end
+
+        def resolve_alias(input)
+          input
+        end
+
+        def get_client(provider, model:, timeout: nil)
+          @clients.fetch(provider)
         end
       end
 

--- a/ace-llm/test/molecules/fallback_orchestrator_test.rb
+++ b/ace-llm/test/molecules/fallback_orchestrator_test.rb
@@ -463,6 +463,17 @@ module Ace
             @clients = {}
           end
 
+          def available_providers
+            @clients.keys.map { |key| key.split(":", 2).first }.uniq.sort
+          end
+
+          def models_for_provider(provider)
+            @clients.keys
+              .select { |key| key.split(":", 2).first == provider }
+              .map { |key| key.split(":", 2)[1] }
+              .compact
+          end
+
           def add_client(provider, client, model: nil)
             key = model ? "#{provider}:#{model}" : provider
             @clients[key] = client

--- a/ace-monorepo-e2e/README.md
+++ b/ace-monorepo-e2e/README.md
@@ -4,14 +4,14 @@ Cross-cutting E2E test scenarios for monorepo-level concerns.
 
 This is **not** a Ruby gem. It is a container for E2E scenarios that span multiple packages or verify monorepo-wide behavior (install verification, quick-start doc validation, etc.).
 
-Scenarios here are auto-discovered by `ace-test-e2e-suite` via the standard `test/e2e/TS-*/scenario.yml` pattern.
+Scenarios here are auto-discovered by `ace-test-e2e-suite`. During migration, keep both path contracts in mind: legacy `test/e2e/TS-*/scenario.yml` and the newer `test-e2e/scenarios/TS-*/scenario.yml`.
 
 ## Running
 
 ```bash
-ace-test-e2e ace-monorepo-e2e                         # run all monorepo scenarios
-ace-test-e2e ace-monorepo-e2e --test-id TS-MONO-001   # run specific scenario
-ace-test-e2e-suite --tags quickstart                   # cross-package quickstart sweep
+ace-test-e2e ace-monorepo-e2e               # run all monorepo scenarios
+ace-test-e2e ace-monorepo-e2e TS-MONO-001   # run specific scenario
+ace-test-e2e-suite --tags quickstart        # cross-package quickstart sweep
 ```
 
 ## Scenarios

--- a/ace-test-runner-e2e/CHANGELOG.md
+++ b/ace-test-runner-e2e/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.10] - 2026-04-10
+
+### Changed
+- Documented dual-path migration contract in `.ace/e2e-runner/config.yml` by keeping explicit legacy fallback keys (`paths.scenarios_legacy`, `patterns.discovery_legacy`) alongside `test-e2e/scenarios`.
+
+## [0.29.9] - 2026-04-10
+
+### Fixed
+- Enforced separate runner/verifier provider threading in the deterministic pipeline so verifier isolation configured in `.ace/e2e-runner/config.yml` is applied at runtime and preserved in report metadata.
+- Aligned scenario discovery with the `test-e2e/scenarios` contract while retaining legacy `test/e2e` fallback support for compatibility during migration.
+
 ## [0.29.8] - 2026-04-01
 
 ### Fixed

--- a/ace-test-runner-e2e/CHANGELOG.md
+++ b/ace-test-runner-e2e/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.11] - 2026-04-10
+
+### Fixed
+- Captured `git diff` stderr during affected-package detection so invalid refs no longer leak fatal git output into otherwise passing test runs.
+
 ## [0.29.10] - 2026-04-10
 
 ### Changed

--- a/ace-test-runner-e2e/docs/demo/ace-test-runner-e2e-path-contract-recovery.tape.yml
+++ b/ace-test-runner-e2e/docs/demo/ace-test-runner-e2e-path-contract-recovery.tape.yml
@@ -1,0 +1,42 @@
+---
+description: Showcase recovered legacy path support and pipeline provider/env threading for ace-test-runner-e2e
+tags:
+- ace-test-runner-e2e
+- feature-demo
+- migration-recovery
+settings:
+  font_size: 16
+  width: 1100
+  height: 720
+  format: gif
+  env:
+    PROJECT_ROOT_PATH: /home/mc/ace-t.j82/ace-test-runner-e2e
+setup:
+- sandbox
+scenes:
+- name: Demo context
+  commands:
+  - type: echo Path contract recovery for PR 288 && echo Checks legacy scenario discovery plus explicit runner/verifier provider threading.
+    sleep: 5s
+- name: Legacy path inference still works
+  commands:
+  - type: clear
+    sleep: 1s
+  - type: cd $PROJECT_ROOT_PATH && ace-test test/molecules/scenario_loader_test.rb
+    sleep: 5s
+  - type: cd $PROJECT_ROOT_PATH && ace-test test/molecules/test_discoverer_test.rb
+    sleep: 5s
+- name: Pipeline provider/env contract stays explicit
+  commands:
+  - type: clear
+    sleep: 1s
+  - type: cd $PROJECT_ROOT_PATH && ace-test test/molecules/test_executor_test.rb
+    sleep: 5s
+verify:
+  forbid_output:
+  - "0 failures, 1 errors"
+  - "1 failures, 0 errors"
+  - "No test files found matching pattern"
+  - "No such file or directory"
+teardown:
+- cleanup

--- a/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/cli/commands/run_test.rb
+++ b/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/cli/commands/run_test.rb
@@ -20,7 +20,7 @@ module Ace
             desc <<~DESC.strip
               Run E2E tests via LLM execution
 
-              Discovers and executes TS-* test scenarios in a package's test/e2e/ directory.
+              Discovers and executes TS-* test scenarios in a package's test-e2e/scenarios/ directory.
               Tests are sent to an LLM provider which executes the test steps and returns
               structured results.
 

--- a/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/affected_detector.rb
+++ b/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/affected_detector.rb
@@ -39,7 +39,7 @@ module Ace
           # @return [Array<String>] Changed file paths
           def get_changed_files(base_dir, ref)
             # Run git diff to get changed files using array-based command for security
-            output, status = Open3.capture2("git", "diff", "--name-only", ref, "--",
+            output, _stderr, status = Open3.capture3("git", "diff", "--name-only", ref, "--",
               chdir: base_dir)
 
             return [] unless status.success?

--- a/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/pipeline_executor.rb
+++ b/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/pipeline_executor.rb
@@ -10,12 +10,16 @@ module Ace
         # Executes standalone scenarios using the deterministic pipeline.
         class PipelineExecutor
           # @param provider [String]
+          # @param runner_provider [String]
+          # @param verifier_provider [String]
           # @param timeout [Integer]
           # @param sandbox_builder [Molecules::PipelineSandboxBuilder]
           # @param prompt_bundler [Molecules::PipelinePromptBundler]
           # @param report_generator [Molecules::PipelineReportGenerator]
-          def initialize(provider:, timeout:, sandbox_builder: nil, prompt_bundler: nil, report_generator: nil)
-            @provider = provider
+          def initialize(provider: nil, runner_provider: nil, verifier_provider: nil, timeout:,
+            sandbox_builder: nil, prompt_bundler: nil, report_generator: nil)
+            @runner_provider = runner_provider || provider
+            @verifier_provider = verifier_provider || provider || @runner_provider
             @timeout = timeout
             @sandbox_builder = sandbox_builder || PipelineSandboxBuilder.new
             @prompt_bundler = prompt_bundler || PipelinePromptBundler.new
@@ -45,6 +49,7 @@ module Ace
               test_cases: test_cases
             )
             run_llm(
+              provider: @runner_provider,
               prompt_path: runner[:prompt_path],
               system_path: runner[:system_path],
               output_path: runner[:output_path],
@@ -58,6 +63,7 @@ module Ace
               test_cases: test_cases
             )
             verifier_response = run_llm(
+              provider: @verifier_provider,
               prompt_path: verifier[:prompt_path],
               system_path: verifier[:system_path],
               output_path: verifier[:output_path],
@@ -69,7 +75,8 @@ module Ace
               scenario: scenario,
               verifier_output: verifier_response[:text],
               report_dir: report_dir,
-              provider: @provider,
+              runner_provider: @runner_provider,
+              verifier_provider: @verifier_provider,
               started_at: started_at,
               completed_at: Time.now
             )
@@ -78,7 +85,8 @@ module Ace
               @report_generator.write_failure_report(
                 scenario: scenario,
                 report_dir: report_dir,
-                provider: @provider,
+                runner_provider: @runner_provider,
+                verifier_provider: @verifier_provider,
                 started_at: started_at || Time.now,
                 completed_at: Time.now,
                 error_message: "#{e.class}: #{e.message}"
@@ -97,13 +105,13 @@ module Ace
 
           private
 
-          def run_llm(prompt_path:, system_path:, output_path:, cli_args:, env_vars:)
+          def run_llm(provider:, prompt_path:, system_path:, output_path:, cli_args:, env_vars:)
             prompt = File.read(prompt_path)
             system = File.read(system_path)
             sandbox_dir = env_vars["PROJECT_ROOT_PATH"] || env_vars[:PROJECT_ROOT_PATH]
 
             Ace::LLM::QueryInterface.query(
-              @provider,
+              provider,
               prompt,
               system: system,
               cli_args: cli_args,

--- a/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/pipeline_report_generator.rb
+++ b/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/pipeline_report_generator.rb
@@ -20,10 +20,15 @@ module Ace
           # @param verifier_output [String]
           # @param report_dir [String]
           # @param provider [String]
+          # @param runner_provider [String]
+          # @param verifier_provider [String]
           # @param started_at [Time]
           # @param completed_at [Time]
           # @return [Models::TestResult]
-          def generate(scenario:, verifier_output:, report_dir:, provider:, started_at:, completed_at:)
+          def generate(scenario:, verifier_output:, report_dir:, provider: nil, runner_provider: nil,
+            verifier_provider: nil, started_at:, completed_at:)
+            resolved_runner_provider = runner_provider || provider
+            resolved_verifier_provider = verifier_provider || provider || resolved_runner_provider
             parsed = parse_verifier_output(verifier_output, scenario)
 
             result = Models::TestResult.new(
@@ -41,7 +46,8 @@ module Ace
             write_goal_report(
               path: File.join(report_dir, "report.md"),
               scenario: scenario,
-              provider: provider,
+              runner_provider: resolved_runner_provider,
+              verifier_provider: resolved_verifier_provider,
               result: result
             )
             result.with_report_dir(report_dir)
@@ -53,11 +59,16 @@ module Ace
           # @param scenario [Models::TestScenario]
           # @param report_dir [String]
           # @param provider [String]
+          # @param runner_provider [String]
+          # @param verifier_provider [String]
           # @param started_at [Time]
           # @param completed_at [Time]
           # @param error_message [String]
           # @return [Models::TestResult]
-          def write_failure_report(scenario:, report_dir:, provider:, started_at:, completed_at:, error_message:)
+          def write_failure_report(scenario:, report_dir:, provider: nil, runner_provider: nil,
+            verifier_provider: nil, started_at:, completed_at:, error_message:)
+            resolved_runner_provider = runner_provider || provider
+            resolved_verifier_provider = verifier_provider || provider || resolved_runner_provider
             result = Models::TestResult.new(
               test_id: scenario.test_id,
               status: "error",
@@ -73,7 +84,8 @@ module Ace
             write_goal_report(
               path: File.join(report_dir, "report.md"),
               scenario: scenario,
-              provider: provider,
+              runner_provider: resolved_runner_provider,
+              verifier_provider: resolved_verifier_provider,
               result: result
             )
             result.with_report_dir(report_dir)
@@ -247,7 +259,7 @@ module Ace
             (summary.length > 240) ? "#{summary[0, 237]}..." : summary
           end
 
-          def write_goal_report(path:, scenario:, provider:, result:)
+          def write_goal_report(path:, scenario:, runner_provider:, verifier_provider:, result:)
             passed = result.passed_count
             failed = result.failed_count
             total = result.total_count
@@ -266,8 +278,8 @@ module Ace
               "test-id" => scenario.test_id,
               "title" => scenario.title,
               "package" => scenario.package,
-              "runner-provider" => provider,
-              "verifier-provider" => provider,
+              "runner-provider" => runner_provider,
+              "verifier-provider" => verifier_provider,
               "timestamp" => result.completed_at.utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
               "tcs-passed" => passed,
               "tcs-failed" => failed,

--- a/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/scenario_loader.rb
+++ b/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/scenario_loader.rb
@@ -237,9 +237,13 @@ module Ace
           # @param scenario_dir [String] Path to scenario directory
           # @return [String] Inferred package name
           def infer_package(scenario_dir)
-            # Expected path: {package}/test/e2e/TS-{AREA}-{NNN}-{slug}/
+            # Expected path: {package}/test-e2e/scenarios/TS-{AREA}-{NNN}-{slug}/
+            # Legacy path fallback: {package}/test/e2e/TS-{AREA}-{NNN}-{slug}/
             parts = File.expand_path(scenario_dir).split("/")
             parts.each_with_index do |part, idx|
+              if part == "test-e2e" && idx > 0 && parts[idx + 1] == "scenarios"
+                return parts[idx - 1]
+              end
               next unless part == "test" && idx > 0 && parts[idx + 1] == "e2e"
 
               return parts[idx - 1]

--- a/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/test_discoverer.rb
+++ b/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/test_discoverer.rb
@@ -9,12 +9,15 @@ module Ace
         # Discovers E2E test scenario directories (TS-*/scenario.yml) in packages
         #
         # Finds test scenarios in the TS-format directory structure:
+        #   {package}/test-e2e/scenarios/TS-*/scenario.yml
+        # Falls back to legacy:
         #   {package}/test/e2e/TS-*/scenario.yml
         #
         # Note: This is a Molecule (not an Atom) because it performs filesystem
         # I/O via Dir.glob.
         class TestDiscoverer
-          TEST_DIR = "test/e2e"
+          TEST_DIR = "test-e2e/scenarios"
+          LEGACY_TEST_DIR = "test/e2e"
           SCENARIO_FILE = "scenario.yml"
           SCENARIO_DIR_PATTERN = "TS-*"
 
@@ -28,8 +31,9 @@ module Ace
           # @return [Array<String>] Sorted list of matching scenario.yml file paths
           def find_tests(package:, test_id: nil, tags: nil, exclude_tags: nil, base_dir: Dir.pwd)
             test_ids = test_id ? test_id.split(",").map(&:strip) : [nil]
+            test_roots = test_dirs(package, base_dir)
             scenario_files = test_ids
-              .flat_map { |id| Dir.glob(build_scenario_pattern(package, id, base_dir)) }
+              .flat_map { |id| test_roots.flat_map { |root| Dir.glob(build_scenario_pattern(root, id)) } }
               .uniq
               .sort
 
@@ -56,9 +60,10 @@ module Ace
           # @param base_dir [String] Base directory to search from
           # @return [Array<Models::TestScenario>] Loaded scenario models with test_cases
           def find_scenarios(package:, test_id: nil, tags: nil, exclude_tags: nil, base_dir: Dir.pwd)
-            test_dir = File.join(base_dir, package, TEST_DIR)
-            pattern = File.join(test_dir, SCENARIO_DIR_PATTERN, SCENARIO_FILE)
-            scenario_files = Dir.glob(pattern).sort
+            scenario_files = test_dirs(package, base_dir)
+              .flat_map { |test_dir| Dir.glob(File.join(test_dir, SCENARIO_DIR_PATTERN, SCENARIO_FILE)) }
+              .uniq
+              .sort
 
             loader = ScenarioLoader.new
             scenarios = scenario_files.map do |yml_path|
@@ -82,11 +87,12 @@ module Ace
           # @param base_dir [String] Base directory to search from
           # @return [Array<String>] Sorted list of package names
           def list_packages(base_dir: Dir.pwd)
-            pattern = File.join(base_dir, "*/#{TEST_DIR}/#{SCENARIO_DIR_PATTERN}/#{SCENARIO_FILE}")
-
             base = Pathname.new(base_dir)
+            patterns = [TEST_DIR, LEGACY_TEST_DIR].map do |dir|
+              File.join(base_dir, "*/#{dir}/#{SCENARIO_DIR_PATTERN}/#{SCENARIO_FILE}")
+            end
 
-            Dir.glob(pattern)
+            patterns.flat_map { |pattern| Dir.glob(pattern) }
               .map { |f| Pathname.new(f).relative_path_from(base).each_filename.first }
               .uniq
               .sort
@@ -95,14 +101,16 @@ module Ace
           private
 
           # Build glob pattern for finding TS-format scenario.yml files
-          def build_scenario_pattern(package, test_id, base_dir)
-            test_dir = File.join(base_dir, package, TEST_DIR)
-
+          def build_scenario_pattern(test_dir, test_id)
             if test_id
               File.join(test_dir, "*#{test_id}*", SCENARIO_FILE)
             else
               File.join(test_dir, SCENARIO_DIR_PATTERN, SCENARIO_FILE)
             end
+          end
+
+          def test_dirs(package, base_dir)
+            [TEST_DIR, LEGACY_TEST_DIR].map { |dir| File.join(base_dir, package, dir) }
           end
 
           def no_filters?(tags, exclude_tags)

--- a/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/test_executor.rb
+++ b/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/molecules/test_executor.rb
@@ -18,7 +18,10 @@ module Ace
           # @param config [Hash] Configuration hash (string keys) from ConfigLoader
           def initialize(provider: nil, timeout: nil, config: nil)
             config ||= Molecules::ConfigLoader.load
-            @provider = provider || config.dig("execution", "provider") || "claude:sonnet"
+            configured_provider = config.dig("execution", "provider") || "claude:sonnet"
+            @provider = provider || configured_provider
+            @runner_provider = provider || config.dig("execution", "runner_provider") || @provider
+            @verifier_provider = provider || config.dig("execution", "verifier_provider") || @runner_provider
             @timeout = timeout || config.dig("execution", "timeout") || 300
             @prompt_builder = Atoms::PromptBuilder.new
             @cli_provider_adapter = Atoms::CliProviderAdapter.new(config)
@@ -37,7 +40,7 @@ module Ace
           def execute(scenario, cli_args: nil, run_id: nil, test_cases: nil, sandbox_path: nil,
             env_vars: nil, report_dir: nil, timeout: nil, verify: false)
             resolved_timeout = timeout || @timeout
-            if Atoms::CliProviderAdapter.cli_provider?(@provider)
+            if Atoms::CliProviderAdapter.cli_provider?(@runner_provider)
               execute_via_pipeline(
                 scenario,
                 cli_args: cli_args,
@@ -63,7 +66,7 @@ module Ace
           # @param env_vars [Hash, nil] Environment variables from setup execution
           # @return [Models::TestResult] Test execution result
           def execute_tc(test_case:, sandbox_path:, scenario:, cli_args: nil, run_id: nil, env_vars: nil)
-            if Atoms::CliProviderAdapter.cli_provider?(@provider)
+            if Atoms::CliProviderAdapter.cli_provider?(@runner_provider)
               execute_tc_via_skill(test_case, sandbox_path, scenario, cli_args: cli_args, run_id: run_id, env_vars: env_vars)
             else
               execute_tc_via_prompt(test_case, sandbox_path, scenario, cli_args: cli_args)
@@ -125,7 +128,7 @@ module Ace
             prompt = @prompt_builder.build(scenario, test_cases: test_cases)
 
             response = Ace::LLM::QueryInterface.query(
-              @provider,
+              @runner_provider,
               prompt,
               system: Atoms::PromptBuilder::SYSTEM_PROMPT,
               cli_args: cli_args,
@@ -198,7 +201,7 @@ module Ace
               )
 
               response = Ace::LLM::QueryInterface.query(
-                @provider, prompt,
+                @runner_provider, prompt,
                 system: nil, cli_args: cli_args,
                 timeout: @timeout, fallback: false,
                 working_dir: sandbox_path,
@@ -240,7 +243,7 @@ module Ace
               )
 
               response = Ace::LLM::QueryInterface.query(
-                @provider, prompt,
+                @runner_provider, prompt,
                 system: Atoms::PromptBuilder::TC_SYSTEM_PROMPT,
                 cli_args: cli_args, timeout: @timeout, fallback: false
               )
@@ -321,7 +324,8 @@ module Ace
             timeout ||= @timeout
             @pipeline_executors ||= {}
             @pipeline_executors[timeout] ||= Molecules::PipelineExecutor.new(
-              provider: @provider,
+              runner_provider: @runner_provider,
+              verifier_provider: @verifier_provider,
               timeout: timeout
             )
           end

--- a/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/version.rb
+++ b/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/version.rb
@@ -3,7 +3,7 @@
 module Ace
   module Test
     module EndToEndRunner
-      VERSION = '0.29.8'
+      VERSION = '0.29.10'
     end
   end
 end

--- a/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/version.rb
+++ b/ace-test-runner-e2e/lib/ace/test/end_to_end_runner/version.rb
@@ -3,7 +3,7 @@
 module Ace
   module Test
     module EndToEndRunner
-      VERSION = '0.29.10'
+      VERSION = '0.29.11'
     end
   end
 end

--- a/ace-test-runner-e2e/test/molecules/affected_detector_test.rb
+++ b/ace-test-runner-e2e/test/molecules/affected_detector_test.rb
@@ -22,9 +22,13 @@ class AffectedDetectorTest < Minitest::Test
   end
 
   def test_detect_with_invalid_ref_returns_empty
-    results = @detector.detect(base_dir: @base_dir, ref: "INVALID-REF-THAT-DOESNT-EXIST")
+    _stdout, stderr = capture_io do
+      results = @detector.detect(base_dir: @base_dir, ref: "INVALID-REF-THAT-DOESNT-EXIST")
 
-    assert_kind_of Array, results
+      assert_equal [], results
+    end
+
+    assert_empty stderr
   end
 
   def test_extract_package_from_ace_package_path

--- a/ace-test-runner-e2e/test/molecules/config_loader_test.rb
+++ b/ace-test-runner-e2e/test/molecules/config_loader_test.rb
@@ -59,7 +59,7 @@ class ConfigLoaderTest < Minitest::Test
 
   def test_cli_providers_accessor
     providers = ConfigLoader.cli_providers
-    assert_equal %w[claude gemini codex codexoss opencode pi], providers
+    assert_equal ConfigLoader.load.dig("providers", "cli"), providers
   end
 
   def test_cli_args_for_claude

--- a/ace-test-runner-e2e/test/molecules/pipeline_report_generator_test.rb
+++ b/ace-test-runner-e2e/test/molecules/pipeline_report_generator_test.rb
@@ -45,6 +45,7 @@ class PipelineReportGeneratorTest < Minitest::Test
 
       goal_report = File.read(File.join(report_dir, "report.md"))
       assert_includes goal_report, "runner-provider: claude:haiku"
+      assert_includes goal_report, "verifier-provider: claude:haiku"
       assert_includes goal_report, "| TC-002 | FAIL |"
     end
   end

--- a/ace-test-runner-e2e/test/molecules/scenario_loader_test.rb
+++ b/ace-test-runner-e2e/test/molecules/scenario_loader_test.rb
@@ -316,6 +316,21 @@ class ScenarioLoaderTest < Minitest::Test
 
   def test_infer_package_from_path
     Dir.mktmpdir do |tmpdir|
+      pkg_dir = File.join(tmpdir, "ace-lint", "test-e2e", "scenarios", "TS-LINT-001-test")
+      FileUtils.mkdir_p(pkg_dir)
+      File.write(File.join(pkg_dir, "scenario.yml"), <<~YAML)
+        test-id: TS-LINT-001
+        title: Lint Test
+        area: lint
+      YAML
+
+      scenario = @loader.load(pkg_dir)
+      assert_equal "ace-lint", scenario.package
+    end
+  end
+
+  def test_infer_package_from_legacy_path
+    Dir.mktmpdir do |tmpdir|
       pkg_dir = File.join(tmpdir, "ace-lint", "test", "e2e", "TS-LINT-001-test")
       FileUtils.mkdir_p(pkg_dir)
       File.write(File.join(pkg_dir, "scenario.yml"), <<~YAML)

--- a/ace-test-runner-e2e/test/molecules/test_discoverer_test.rb
+++ b/ace-test-runner-e2e/test/molecules/test_discoverer_test.rb
@@ -227,10 +227,30 @@ class TestDiscovererTest < Minitest::Test
     end
   end
 
+  def test_find_tests_supports_legacy_test_e2e_path
+    Dir.mktmpdir do |tmpdir|
+      create_legacy_ts_scenario(tmpdir, "ace-lint", "TS-LINT-001-test", ["TC-001"])
+
+      files = @discoverer.find_tests(package: "ace-lint", base_dir: tmpdir)
+
+      assert_equal 1, files.size
+      assert_includes files.first, "/test/e2e/"
+    end
+  end
+
   private
 
   def create_ts_scenario(base_dir, package, scenario_name, tc_ids, tags: nil)
+    scenario_dir = File.join(base_dir, package, "test-e2e", "scenarios", scenario_name)
+    write_ts_scenario(scenario_dir, scenario_name, tc_ids, tags: tags)
+  end
+
+  def create_legacy_ts_scenario(base_dir, package, scenario_name, tc_ids, tags: nil)
     scenario_dir = File.join(base_dir, package, "test", "e2e", scenario_name)
+    write_ts_scenario(scenario_dir, scenario_name, tc_ids, tags: tags)
+  end
+
+  def write_ts_scenario(scenario_dir, scenario_name, tc_ids, tags: nil)
     FileUtils.mkdir_p(scenario_dir)
 
     test_id = scenario_name.split("-")[0..2].join("-")

--- a/ace-test-runner-e2e/test/molecules/test_executor_test.rb
+++ b/ace-test-runner-e2e/test/molecules/test_executor_test.rb
@@ -68,7 +68,14 @@ class TestExecutorTest < Minitest::Test
       sandbox_path = File.join(tmpdir, "sandbox")
       report_dir = File.join(tmpdir, "reports")
       scenario = create_pipeline_scenario(scenario_dir)
-      executor = TestExecutor.new(provider: "claude:sonnet", timeout: 10)
+      config = {
+        "execution" => {
+          "provider" => "claude:sonnet",
+          "runner_provider" => "claude:runner",
+          "verifier_provider" => "gemini:verifier"
+        }
+      }
+      executor = TestExecutor.new(timeout: 10, config: config)
 
       calls = []
       responses = [
@@ -89,7 +96,7 @@ class TestExecutorTest < Minitest::Test
 
       stub_sandbox_builder do
         Ace::LLM::QueryInterface.stub(:query, lambda { |*args, **kwargs|
-          calls << {prompt: args[1], kwargs: kwargs}
+          calls << {provider: args[0], kwargs: kwargs}
           responses.shift
         }) do
           result = executor.execute(
@@ -107,11 +114,16 @@ class TestExecutorTest < Minitest::Test
       end
 
       assert_equal 2, calls.size, "runner and verifier should both execute"
+      assert_equal "claude:runner", calls.first[:provider]
+      assert_equal "gemini:verifier", calls.last[:provider]
       assert File.exist?(File.join(report_dir, "metadata.yml")), "pipeline should write metadata"
       assert_equal "value", calls.first[:kwargs][:subprocess_env]["CUSTOM"]
       assert_equal File.expand_path(sandbox_path), calls.first[:kwargs][:subprocess_env]["PROJECT_ROOT_PATH"]
       assert_equal File.expand_path(sandbox_path), calls.first[:kwargs][:working_dir]
       assert_equal File.expand_path(sandbox_path), calls.last[:kwargs][:working_dir]
+      goal_report = File.read(File.join(report_dir, "report.md"))
+      assert_includes goal_report, "runner-provider: claude:runner"
+      assert_includes goal_report, "verifier-provider: gemini:verifier"
     end
   end
 

--- a/ace-test-runner/CHANGELOG.md
+++ b/ace-test-runner/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.6] - 2026-04-10
+
+### Fixed
+- Restored suite-enforced `--run-in-single-batch` execution so `ace-test-suite` preserves its package execution contract instead of falling back to grouped runs.
+- Prefer live runtime timeout/failure state over stale `latest/summary.json` data so suite aggregation no longer reports timed-out packages as passed.
+- Detect subprocess-sensitive tests by file content even inside unit directories, preventing single-batch in-process hangs for packages like `ace-test-runner-e2e`.
+
 ## [0.19.5] - 2026-04-10
 
 ### Fixed

--- a/ace-test-runner/CHANGELOG.md
+++ b/ace-test-runner/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Added a suite-completeness regression guard in `PackageResolverTest` that fails when `.ace/test/suite.yml` omits testable packages discovered from the mono-repo.
+
 ## [0.19.3] - 2026-04-07
 
 ### Technical

--- a/ace-test-runner/CHANGELOG.md
+++ b/ace-test-runner/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.5] - 2026-04-10
+
 ### Fixed
-- Added a suite-completeness regression guard in `PackageResolverTest` that fails when `.ace/test/suite.yml` omits testable packages discovered from the mono-repo.
+- Stopped forcing `--run-in-single-batch` in suite package execution so `ace-test-suite` uses the stable grouped package path instead of the hanging single-batch mode.
+- Prefer live runtime timeout/failure state over stale `latest/summary.json` data so suite aggregation no longer reports timed-out packages as passed.
 
 ## [0.19.3] - 2026-04-07
 

--- a/ace-test-runner/lib/ace/test_runner/atoms/test_type_detector.rb
+++ b/ace-test-runner/lib/ace/test_runner/atoms/test_type_detector.rb
@@ -39,20 +39,24 @@ module Ace
           # Check if explicitly marked as needing isolation
           return true if isolation_directory?(file_path)
 
-          # Check if it's clearly a unit test that doesn't need isolation
+          # Check file content for patterns that require subprocess
+          needs_isolation = check_file_content(file_path)
+          return true if needs_isolation
+
+          # Unit-directory tests default to in-process only when they do not
+          # exercise subprocess-sensitive behavior directly.
           return false if unit_test_directory?(file_path)
 
-          # Check file content for patterns that require subprocess
-          check_file_content(file_path)
+          false
         end
 
         def test_type(file_path)
           if isolation_directory?(file_path)
             :integration
-          elsif unit_test_directory?(file_path)
-            :unit
           elsif check_file_content(file_path)
             :subprocess_required
+          elsif unit_test_directory?(file_path)
+            :unit
           else
             :unit
           end

--- a/ace-test-runner/lib/ace/test_runner/suite/process_monitor.rb
+++ b/ace-test-runner/lib/ace/test_runner/suite/process_monitor.rb
@@ -182,6 +182,10 @@ module Ace
         def build_command(package, options)
           cmd_parts = ["ace-test"]
 
+          # Suite package execution intentionally bypasses grouped mode so each
+          # package runs its full target scope as one batch under suite orchestration.
+          cmd_parts << "--run-in-single-batch"
+
           # Add format (use progress if compact is specified since ace-test doesn't have compact format)
           format = options["format"] || "progress"
           format = "progress" if format == "compact"  # Handle legacy compact format

--- a/ace-test-runner/lib/ace/test_runner/suite/process_monitor.rb
+++ b/ace-test-runner/lib/ace/test_runner/suite/process_monitor.rb
@@ -182,10 +182,6 @@ module Ace
         def build_command(package, options)
           cmd_parts = ["ace-test"]
 
-          # Always run in single batch for suite execution
-          # This avoids nested group headers and improves performance
-          cmd_parts << "--run-in-single-batch"
-
           # Add format (use progress if compact is specified since ace-test doesn't have compact format)
           format = options["format"] || "progress"
           format = "progress" if format == "compact"  # Handle legacy compact format

--- a/ace-test-runner/lib/ace/test_runner/suite/result_aggregator.rb
+++ b/ace-test-runner/lib/ace/test_runner/suite/result_aggregator.rb
@@ -47,6 +47,9 @@ module Ace
 
         def collect_results
           @packages.map do |package|
+            runtime = runtime_result(package)
+            next runtime if runtime_result_overrides_summary?(package, runtime)
+
             reports_dir = Atoms::ReportPathResolver.report_directory(
               package["path"],
               report_root: @report_root,
@@ -91,7 +94,7 @@ module Ace
                 }
               end
             else
-              runtime_result(package) || {
+              runtime || {
                 package: package["name"],
                 path: package["path"],
                 report_root: @report_root,
@@ -104,6 +107,13 @@ module Ace
               }
             end
           end
+        end
+
+        def runtime_result_overrides_summary?(package, runtime)
+          return false unless runtime
+
+          status = @runtime_results[package["name"]] || {}
+          status[:timed_out] || status[:interrupted] || runtime[:success] == false
         end
 
         def collect_failed_packages(results)

--- a/ace-test-runner/lib/ace/test_runner/version.rb
+++ b/ace-test-runner/lib/ace/test_runner/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module TestRunner
-    VERSION = '0.19.5'
+    VERSION = '0.19.6'
   end
 end

--- a/ace-test-runner/lib/ace/test_runner/version.rb
+++ b/ace-test-runner/lib/ace/test_runner/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module TestRunner
-    VERSION = '0.19.3'
+    VERSION = '0.19.4'
   end
 end

--- a/ace-test-runner/lib/ace/test_runner/version.rb
+++ b/ace-test-runner/lib/ace/test_runner/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module TestRunner
-    VERSION = '0.19.4'
+    VERSION = '0.19.5'
   end
 end

--- a/ace-test-runner/test/atoms/test_type_detector_test.rb
+++ b/ace-test-runner/test/atoms/test_type_detector_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "ace/test_runner/atoms/test_type_detector"
+
+module Ace
+  module TestRunner
+    module Atoms
+      class TestTypeDetectorTest < Minitest::Test
+        def test_needs_subprocess_for_unit_directory_file_when_content_uses_open3
+          Dir.mktmpdir do |tmpdir|
+            file_path = File.join(tmpdir, "test", "molecules", "example_test.rb")
+            FileUtils.mkdir_p(File.dirname(file_path))
+            File.write(file_path, <<~RUBY)
+              require "open3"
+
+              class ExampleTest < Minitest::Test
+                def test_runs_command
+                  Open3.capture3("echo", "hi")
+                end
+              end
+            RUBY
+
+            detector = Ace::TestRunner::Atoms::TestTypeDetector.new
+
+            assert detector.needs_subprocess?(file_path)
+            assert_equal :subprocess_required, detector.test_type(file_path)
+          end
+        end
+
+        def test_keeps_plain_unit_directory_file_in_process
+          Dir.mktmpdir do |tmpdir|
+            file_path = File.join(tmpdir, "test", "organisms", "example_test.rb")
+            FileUtils.mkdir_p(File.dirname(file_path))
+            File.write(file_path, <<~RUBY)
+              class ExampleTest < Minitest::Test
+                def test_truth
+                  assert true
+                end
+              end
+            RUBY
+
+            detector = Ace::TestRunner::Atoms::TestTypeDetector.new
+
+            refute detector.needs_subprocess?(file_path)
+            assert_equal :unit, detector.test_type(file_path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/ace-test-runner/test/integration/suite/process_monitor_test.rb
+++ b/ace-test-runner/test/integration/suite/process_monitor_test.rb
@@ -8,6 +8,22 @@ module Ace
   module TestRunner
     module Suite
       class ProcessMonitorTest < Minitest::Test
+        def test_build_command_does_not_force_single_batch
+          monitor = ProcessMonitor.new
+          package = {"name" => "ace-sample", "path" => "/tmp/ace-sample"}
+
+          command = monitor.send(:build_command, package, {
+            "format" => "progress",
+            "save_reports" => false,
+            "fail_fast" => true,
+            "color" => false,
+            "report_dir" => "/tmp/reports"
+          })
+
+          refute_includes command, "--run-in-single-batch"
+          assert_equal ["ace-test", "--format", "progress", "--no-save", "--fail-fast", "--no-color", "--report-dir", "/tmp/reports/sample"], command
+        end
+
         class FakeProcessMonitor < ProcessMonitor
           def initialize(command_map:, **kwargs)
             max_parallel = kwargs.delete(:max_parallel) || 10

--- a/ace-test-runner/test/integration/suite/process_monitor_test.rb
+++ b/ace-test-runner/test/integration/suite/process_monitor_test.rb
@@ -8,7 +8,7 @@ module Ace
   module TestRunner
     module Suite
       class ProcessMonitorTest < Minitest::Test
-        def test_build_command_does_not_force_single_batch
+        def test_build_command_forces_single_batch_for_suite_execution
           monitor = ProcessMonitor.new
           package = {"name" => "ace-sample", "path" => "/tmp/ace-sample"}
 
@@ -20,8 +20,8 @@ module Ace
             "report_dir" => "/tmp/reports"
           })
 
-          refute_includes command, "--run-in-single-batch"
-          assert_equal ["ace-test", "--format", "progress", "--no-save", "--fail-fast", "--no-color", "--report-dir", "/tmp/reports/sample"], command
+          assert_includes command, "--run-in-single-batch"
+          assert_equal ["ace-test", "--run-in-single-batch", "--format", "progress", "--no-save", "--fail-fast", "--no-color", "--report-dir", "/tmp/reports/sample"], command
         end
 
         class FakeProcessMonitor < ProcessMonitor

--- a/ace-test-runner/test/integration/suite/result_aggregator_test.rb
+++ b/ace-test-runner/test/integration/suite/result_aggregator_test.rb
@@ -83,6 +83,46 @@ module Ace
             assert_equal "Timed out after 10 seconds", summary[:failed_packages].first[:error_message]
           end
         end
+
+        def test_aggregate_prefers_runtime_timeout_over_stale_summary
+          Dir.mktmpdir do |tmpdir|
+            package_path = File.join(tmpdir, "ace-timeout")
+            report_root = File.join(tmpdir, ".ace-local", "test", "reports")
+            latest_dir = File.join(report_root, "timeout", "latest")
+
+            FileUtils.mkdir_p(package_path)
+            FileUtils.mkdir_p(latest_dir)
+            File.write(File.join(latest_dir, "summary.json"), JSON.generate({
+              total: 5, passed: 5, failed: 0, errors: 0, skipped: 0, duration: 0.5, success: true
+            }))
+
+            summary = ResultAggregator.new(
+              [{"name" => "ace-timeout", "path" => package_path}],
+              report_root: report_root,
+              runtime_results: {
+                "ace-timeout" => {
+                  completed: true,
+                  success: false,
+                  elapsed: 15.0,
+                  timed_out: true,
+                  results: {
+                    tests: 0,
+                    failures: 0,
+                    errors: 1,
+                    duration: 15.0,
+                    success: false,
+                    error: "Timed out after 15 seconds"
+                  }
+                }
+              }
+            ).aggregate
+
+            assert_equal 0, summary[:packages_passed]
+            assert_equal 1, summary[:packages_failed]
+            assert_equal 0, summary[:total_tests]
+            assert_equal "Timed out after 15 seconds", summary[:failed_packages].first[:error_message]
+          end
+        end
       end
     end
   end

--- a/ace-test-runner/test/molecules/package_resolver_test.rb
+++ b/ace-test-runner/test/molecules/package_resolver_test.rb
@@ -4,6 +4,7 @@ require_relative "../test_helper"
 require "ace/test_runner/molecules/package_resolver"
 require "tmpdir"
 require "fileutils"
+require "yaml"
 
 class PackageResolverTest < Minitest::Test
   def setup
@@ -132,6 +133,18 @@ class PackageResolverTest < Minitest::Test
     assert packages.include?("ace-bundle"), "Should include ace-bundle"
     assert packages.include?("ace-support-nav"), "Should include ace-support-nav"
     assert packages.include?("ace-test-runner"), "Should include ace-test-runner"
+  end
+
+  def test_suite_config_includes_all_testable_packages
+    suite_path = File.join(mono_repo_root, ".ace", "test", "suite.yml")
+    suite_config = YAML.load_file(suite_path)
+    configured = suite_config["test_suite"]["packages"].map { |pkg| pkg["name"] }
+
+    resolver = Ace::TestRunner::Molecules::PackageResolver.new(project_root: mono_repo_root)
+    available = resolver.available_packages
+
+    missing = available - configured
+    assert_equal [], missing, "Suite config is missing packages: #{missing.join(", ")}"
   end
 
   def test_available_packages_only_includes_packages_with_tests


### PR DESCRIPTION
## 📋 Summary

Reviewing and shipping the recovered `fix/e2e` follow-ups is easier now because the branch ends in a clean, truthful test state instead of an inconsistent mix of recovered fixes and broken suite behavior.

Before this final pass, the recovery work had restored the missing package behavior and docs, but the monorepo test story still had a bad edge: `ace-test-suite` could be driven through the wrong execution path, stale package summaries could hide live failures, and single-batch execution could hang when subprocess-sensitive tests lived under unit directories.

This PR now closes that loop. It restores the recovered package/config fixes from `fix/e2e`, carries the shared E2E path-contract/documentation updates through release, and finishes with a corrected `ace-test-runner` follow-up so package runs, single-batch runs, and the full suite all agree again.

## ✏️ Changes

- Restore **`ace-llm-providers-cli`** subprocess env forwarding and Gemini CLI working-directory handling so CLI providers execute in the intended environment again.
- Re-enable **packaged `git.split` defaults** in `ace-git-commit` and lock the contract with regression coverage.
- Rebuild **`ace-llm` fallback selector state** per provider target so fallback chains stop reusing stale generation options.
- Recover the shared **E2E path contract** across `ace-assign`, `ace-test-runner-e2e`, repo config, docs, and demo guidance so both migrated `test-e2e/scenarios` and legacy `test/e2e` layouts remain usable during the transition.
- Harden **`ace-git-worktree` cleanup** so prune failures surface immediately when directories remain after attempted removal.
- Restore **monorepo suite inventory coverage** in `ace-test-runner`, then follow it with a corrective runner release that keeps suite-enforced single-batch execution, prefers live runtime failure state over stale summaries, and auto-detects subprocess-sensitive tests even inside unit directories.
- Add **post-review release/docs follow-through** and keep the recovered behavior reproducible with a verified E2E demo tape attached to the PR.

## 📁 File Changes

```text
+1143,  -185   80 files   total

  +10,    -4    4 files      ace-assign/
   +2,    -2    2 files   🧱 lib/
   +1,    -1                 ace/assign/organisms/assignment_executor.rb
   +1,    -1                 ace/assign/version.rb
   +8,    -2    2 files      
   +2,    -2                 .ace-defaults/assign/presets/work-on-task.yml
   +6,    -0                 CHANGELOG.md

   +6,    -1    2 files      ace-docs/
   +1,    -1    1 files   🧱 lib/
   +1,    -1                 ace/docs/version.rb
   +5,    -0    1 files      
   +5,    -0                 CHANGELOG.md

  +27,    -1    4 files      ace-git-commit/
   +1,    -1    1 files   🧱 lib/
   +1,    -1                 ace/git_commit/version.rb
  +15,    -0    1 files   🧪 test/
  +15,    -0                 default_config_test.rb
  +11,    -0    2 files      
   +5,    -0                 .ace-defaults/git/commit.yml
   +6,    -0                 CHANGELOG.md

  +56,    -6    5 files      ace-git-worktree/
  +10,    -6    2 files   🧱 lib/
   +9,    -5                 ace/git/worktree/molecules/worktree_remover.rb
   +1,    -1                 ace/git/worktree/version.rb
  +37,    -0    2 files   🧪 test/
  +15,    -0                 commands/prune_command_test.rb
  +22,    -0                 molecules/worktree_remover_test.rb
   +9,    -0    1 files      
   +9,    -0                 CHANGELOG.md

  +13,   -13    4 files      ace-handbook/
   +7,    -7    2 files   📚 handbook/
   +5,    -5                 cookbooks/setup-starting-a-multi-ruby-gem-monorepo-with-ace.cookbook.md
   +2,    -2                 skills/as-release-rubygems-publish/SKILL.md
   +6,    -6    2 files      
   +3,    -3                 docs/release-rubygems-proof.md
   +3,    -3                 .../usage.md

   +1,    -1    1 files      ace-hitl/
   +1,    -1                 commands/hitl_cli_test.rb

  +66,   -12    6 files      ace-llm-providers-cli/
  +17,   -12    3 files   🧱 lib/
   +1,    -0                 ace/llm/providers/cli/codex_client.rb
  +15,   -11                 .../gemini_client.rb
   +1,    -1                 .../version.rb
  +40,    -0    2 files   🧪 test/
  +22,    -0                 molecules/codex_client_test.rb
  +18,    -0                 .../gemini_client_test.rb
   +9,    -0    1 files      
   +9,    -0                 CHANGELOG.md

 +251,   -42    6 files      ace-llm/
 +112,   -42    3 files   🧱 lib/
  +14,    -8                 ace/llm/molecules/fallback_orchestrator.rb
  +97,   -33                 ace/llm/query_interface.rb
   +1,    -1                 .../version.rb
 +136,    -0    2 files   🧪 test/
 +125,    -0                 integration/query_interface_fallback_test.rb
  +11,    -0                 molecules/fallback_orchestrator_test.rb
   +3,    -0    1 files      
   +3,    -0                 CHANGELOG.md

   +2,    -2    1 files      ace-monorepo-e2e/
   +2,    -2                 README.md

 +185,   -39   16 files      ace-test-runner-e2e/
  +71,   -35    8 files   🧱 lib/
   +1,    -1                 ace/test/end_to_end_runner/cli/commands/run_test.rb
   +1,    -1                 ace/test/end_to_end_runner/molecules/affected_detector.rb
  +14,    -6                 .../pipeline_executor.rb
  +19,    -7                 .../pipeline_report_generator.rb
   +5,    -1                 .../scenario_loader.rb
  +19,   -11                 .../test_discoverer.rb
  +11,    -7                 .../test_executor.rb
   +1,    -1                 ace/test/end_to_end_runner/version.rb
  +56,    -4    6 files   🧪 test/
   +5,    -1                 molecules/affected_detector_test.rb
   +1,    -1                 .../config_loader_test.rb
   +1,    -0                 .../pipeline_report_generator_test.rb
  +15,    -0                 .../scenario_loader_test.rb
  +20,    -0                 .../test_discoverer_test.rb
  +14,    -2                 .../test_executor_test.rb
  +58,    -0    2 files      
  +16,    -0                 CHANGELOG.md
  +42,    -0                 docs/demo/ace-test-runner-e2e-path-contract-recovery.tape.yml

 +157,    -9    9 files      ace-test-runner/
  +23,    -9    4 files   🧱 lib/
   +9,    -5                 ace/test_runner/atoms/test_type_detector.rb
   +2,    -2                 ace/test_runner/suite/process_monitor.rb
  +11,    -1                 .../result_aggregator.rb
   +1,    -1                 ace/test_runner/version.rb
 +121,    -0    4 files   🧪 test/
  +52,    -0                 atoms/test_type_detector_test.rb
  +16,    -0                 integration/suite/process_monitor_test.rb
  +40,    -0                 .../result_aggregator_test.rb
  +13,    -0                 molecules/package_resolver_test.rb
  +13,    -0    1 files      
  +13,    -0                 CHANGELOG.md

  +49,   -49    8 files      .ace-tasks/
   +7,    -7                 8r9.t.j82-migrate-pr-285-package-config/0-recover-ace-llm-providers-cli/8r9.t.j82.0-recover-ace-llm-providers-cli-fixes-from.s.md -> _archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/0-recover-ace-llm-providers-cli/8r9.t.j82.0-recover-ace-llm-providers-cli-fixes-from.s.md
   +6,    -6                 8r9.t.j82-migrate-pr-285-package-config/1-recover-ace-git-commit-fixes/8r9.t.j82.1-recover-ace-git-commit-fixes-from-fixe2e.s.md -> _archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/1-recover-ace-git-commit-fixes/8r9.t.j82.1-recover-ace-git-commit-fixes-from-fixe2e.s.md
   +7,    -7                 8r9.t.j82-migrate-pr-285-package-config/2-recover-ace-llm-fixes-from/8r9.t.j82.2-recover-ace-llm-fixes-from-fixe2e.s.md -> _archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/2-recover-ace-llm-fixes-from/8r9.t.j82.2-recover-ace-llm-fixes-from-fixe2e.s.md
   +7,    -7                 8r9.t.j82-migrate-pr-285-package-config/3-recover-main-monorepo-config-fixes/8r9.t.j82.3-recover-main-monorepo-config-fixes-from-fixe2e.s.md -> _archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/3-recover-main-monorepo-config-fixes/8r9.t.j82.3-recover-main-monorepo-config-fixes-from-fixe2e.s.md
   +5,    -5                 8r9.t.j82-migrate-pr-285-package-config/4-recover-ace-test-runner-fixes/8r9.t.j82.4-recover-ace-test-runner-fixes-from-fixe2e.s.md -> _archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/4-recover-ace-test-runner-fixes/8r9.t.j82.4-recover-ace-test-runner-fixes-from-fixe2e.s.md
   +7,    -7                 8r9.t.j82-migrate-pr-285-package-config/5-recover-ace-git-worktree-fixes/8r9.t.j82.5-recover-ace-git-worktree-fixes-from-fixe2e.s.md -> _archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/5-recover-ace-git-worktree-fixes/8r9.t.j82.5-recover-ace-git-worktree-fixes-from-fixe2e.s.md
   +9,    -9                 8r9.t.j82-migrate-pr-285-package-config/6-recover-shared-e2e-contract-fixes/8r9.t.j82.6-recover-shared-e2e-role-and-path-contract.s.md -> _archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/6-recover-shared-e2e-contract-fixes/8r9.t.j82.6-recover-shared-e2e-role-and-path-contract.s.md
   +1,    -1                 8r9.t.j82-migrate-pr-285-package-config/8r9.t.j82-migrate-pr-285-package-config-fixes-as.s.md -> _archive/8r/w/8r9.t.j82-migrate-pr-285-package-config/8r9.t.j82-migrate-pr-285-package-config-fixes-as.s.md

  +74,    -6    5 files      .ace/
  +55,    -0    1 files   🧪 test/
  +55,    -0                 suite.yml
  +19,    -6    4 files      
   +1,    -1                 bundle/presets/project.md
   +1,    -0                 docs/config.yml
  +11,    -3                 e2e-runner/config.yml
   +6,    -2                 llm/config.yml

 +234,    -0    8 files      .ace-retros/
  +26,    -0                 8r9koj-8r9kdv-01001-recover-ace-llm/8r9koj-8r9kdv-01001-recover-ace-llm-providers-cli.retro.md
  +26,    -0                 8r9l1t-retro-8r9kdv-01002-8r9tj821/8r9l1t-retro-8r9kdv-01002-8r9tj821.retro.md
  +26,    -0                 8r9lcl-retro-8r9kdv-01003-task-8r9tj822/8r9lcl-retro-8r9kdv-01003-task-8r9tj822.retro.md
  +26,    -0                 8r9low-retro-8r9kdv-01004-task-8r9tj823/8r9low-retro-8r9kdv-01004-task-8r9tj823.retro.md
  +25,    -0                 8r9lwu-retro-8r9kdv-01005-task-8r9tj824/8r9lwu-retro-8r9kdv-01005-task-8r9tj824.retro.md
  +34,    -0                 8r9m81-8r9tj825-worktree-fix-recovery/8r9m81-8r9tj825-worktree-fix-recovery.retro.md
  +48,    -0                 8r9oei-batch-recovery-fix-e2e-followups/8r9oei-batch-recovery-fix-e2e-followups.retro.md
  +23,    -0                 _archive/8r/w/8r9mh8-8r9tj826-shared-e2e-contract-recovery/8r9mh8-8r9tj826-shared-e2e-contract-recovery.retro.md

  +12,    -0    1 files      ./
  +12,    -0                 CHANGELOG.md
```

## 🧪 Test Evidence

- **DefaultConfigTest** validates the restored packaged `git.split` defaults and explicit no-split override contract in `ace-git-commit`.
- **CodexClientTest** and **GeminiClientTest** verify propagated subprocess env handling and corrected Gemini CLI execution behavior.
- **QueryInterfaceFallbackTest** and **FallbackOrchestratorTest** validate fallback selector rebuilding and provider-specific option preservation in `ace-llm`.
- **ScenarioLoaderTest**, **TestDiscovererTest**, **TestExecutorTest**, and **AffectedDetectorTest** cover legacy `test/e2e` inference, migrated scenario discovery, provider/env threading, invalid-ref handling, and the recovered shared E2E path contract.
- **PackageResolverTest**, **ProcessMonitorTest**, **ResultAggregatorTest**, and **TestTypeDetectorTest** validate suite inventory completeness, runtime-result precedence over stale summaries, restored suite single-batch enforcement, and subprocess detection for unit-directory tests.
- **PruneCommandTest** and **WorktreeRemoverTest** verify hard-failure cleanup behavior in `ace-git-worktree`.
- **ace-test ace-test-runner --run-in-single-batch --format progress** passed with **203 tests and 546 assertions**, confirming the corrected single-batch runner path.
- **ace-test-suite** passed green with **43 passed packages, 8540 passed tests, 56 skipped tests, and 23209 passed assertions** after the final `ace-test-runner` correction.
- **Demo tape verification** — `ace-demo record docs/demo/ace-test-runner-e2e-path-contract-recovery.tape.yml --pr 288` passed semantic verification and posted the recording to the PR comments.

## 📦 Releases

- **ace-llm-providers-cli v0.27.3** — restore CLI subprocess env forwarding and Gemini working-dir resolution.
- **ace-git-commit v0.23.7** — restore packaged split defaults and regression coverage.
- **ace-llm v0.32.2** — rebuild fallback selector options per provider target.
- **ace-test-runner v0.19.4** — guard suite inventory completeness.
- **ace-test-runner v0.19.5** — make runtime failure state override stale suite summaries.
- **ace-test-runner v0.19.6** — restore suite single-batch enforcement and subprocess-sensitive test isolation.
- **ace-git-worktree v0.19.5** — fail fast when worktree cleanup leaves directories behind.
- **ace-assign v0.44.5** — recover shared E2E path handling across assignment execution and presets.
- **ace-docs v0.32.1** — keep legacy E2E markdown ignored during the migration window.
- **ace-test-runner-e2e v0.29.10** — migrate execution to the new path contract while preserving legacy discovery compatibility.
- **ace-test-runner-e2e v0.29.11** — silence invalid-ref `git diff` stderr leakage during affected-package detection.

## 🎮 Demo

See attached demo recording in PR comments below.

### Run

```bash
cd ace-test-runner
ace-test --run-in-single-batch --format progress

cd ../ace-test-runner-e2e
ace-test test/molecules/scenario_loader_test.rb
ace-test test/molecules/test_discoverer_test.rb
ace-test test/molecules/test_executor_test.rb
```

### Expected Output

- `ace-test --run-in-single-batch --format progress` passes for `ace-test-runner`, confirming the suite runner can use the intended single-batch execution contract without hanging or hiding failures.
- The targeted `ace-test-runner-e2e` molecule checks pass, proving legacy `test/e2e` path inference, migrated scenario discovery, and explicit runner/verifier provider threading all work together.
- The recorded PR demo shows the same path-contract recovery flow and passed semantic verification before upload.

### Artifacts

- `ace-test-runner` reports are written under `.ace-local/test/reports/test-runner/`
- `ace-test-runner-e2e` reports are written under `.ace-local/test/reports/test-runner-e2e/`
- The recorded demo GIF is attached in PR comments and published at `demo-assets/ace-test-runner-e2e-path-contract-recovery-1775837460.gif`
