### PR TITLE
8r6.t.hl3: enforce unique IDs across task and idea lifecycle commands

### DIFF
--- a/.ace-retros/8rcjp4-assignment-8rcjeb-task-8r6thl30-closeout/8rcjp4-assignment-8rcjeb-task-8r6thl30-closeout.retro.md
+++ b/.ace-retros/8rcjp4-assignment-8rcjeb-task-8r6thl30-closeout/8rcjp4-assignment-8rcjeb-task-8r6thl30-closeout.retro.md
@@ -1,0 +1,28 @@
+---
+id: 8rcjp4
+title: Assignment 8rcjeb task 8r6.t.hl3.0 closeout
+type: self-review
+tags: [assignment, 8rcjeb, 8r6.t.hl3.0]
+created_at: "2026-04-13 13:07:55"
+status: active
+---
+
+# Assignment 8rcjeb task 8r6.t.hl3.0 closeout
+
+## What I Did Well
+- Implemented duplicate persisted-ID detection in both `ace-task` and `ace-idea` doctor organisms without introducing new CLI surface area.
+- Covered required behavior with both organism and CLI tests, including frontmatter-only check mode.
+- Followed assignment sequencing through planning, implementation, review fallback, verification, release, and retro creation without leaving runnable work pending.
+
+## What I Could Improve
+- Release-step skill matching was identified after initial manual command execution; skill selection should be done at step entry.
+- Initial targeted `ace-test` invocation used repo-root paths that caused `test_helper` load errors before rerunning with package working directories.
+
+## Key Learnings
+- In this repo, doctor duplicate-ID checks fit best in organism frontmatter flows because `--check frontmatter` must include integrity failures.
+- Task subtask duplicate coverage requires explicit subtask traversal; top-level scanner results alone are insufficient.
+- `ace-git-commit` may split coordinated release work into scoped commits by configuration, which is acceptable when the full release surface is covered.
+
+## Action Items
+- Add a small drive-loop checklist item for release/retro steps: resolve matching skill before any execution command.
+- Add a reusable local command template for package-scoped test runs (`cd <package> && ace-test ...`) to avoid root-path load errors.

--- a/.ace-retros/8rckbk-assignment-8rcjeb-task-8r6thl31-retrospective/8rckbk-assignment-8rcjeb-task-8r6thl31-retrospective.retro.md
+++ b/.ace-retros/8rckbk-assignment-8rcjeb-task-8r6thl31-retrospective/8rckbk-assignment-8rcjeb-task-8r6thl31-retrospective.retro.md
@@ -1,0 +1,25 @@
+---
+id: 8rckbk
+title: Assignment 8rcjeb task 8r6.t.hl3.1 retrospective
+type: standard
+tags: [assignment, 8rcjeb, 8r6.t.hl3.1]
+created_at: "2026-04-13 13:32:52"
+status: active
+---
+
+# Assignment 8rcjeb task 8r6.t.hl3.1 retrospective
+
+## What Went Well
+- Implemented create-time ID collision retries for both `ace-task` and `ace-idea` with clear exhaustion failures and cleanup guarantees.
+- Added focused command/molecule/feature regression coverage that validated the new ID-integrity contract.
+- Completed subtree verification and release with package-scoped commits and updated changelogs/versions.
+
+## What Could Be Improved
+- `ace-task plan <ref>` and `ace-task plan <ref> --content` stalled repeatedly in this environment and required manual plan execution fallback.
+- `ace-idea` feature tests initially encoded the old same-ID multi-folder behavior and failed during verify-test until updated to match the new contract.
+- `ace-task create --in maybe` surfaced an existing runtime bug (`TaskManager#move` missing) when attempting to place a follow-up task directly into `_maybe`.
+
+## Action Items
+- Track and resolve plan-command stall reliability via follow-up task `8rc.t.k2l`.
+- Add/create regression coverage for `ace-task create --in <folder>` path to prevent `TaskManager#move`-path runtime failures.
+- Keep ID-collision contract synchronized across docs/specs/tests whenever create semantics change.

--- a/.ace-tasks/8r6.t.hl3-enforce-unique-ids-across-task/0-flag-collisions-in-doctor-health/8r6.t.hl3.0-flag-collisions-in-doctor-health-checks-for.s.md
+++ b/.ace-tasks/8r6.t.hl3-enforce-unique-ids-across-task/0-flag-collisions-in-doctor-health/8r6.t.hl3.0-flag-collisions-in-doctor-health-checks-for.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r6.t.hl3.0
-status: in-progress
+status: done
 priority: medium
 created_at: "2026-04-07 11:43:34"
 estimate: TBD

--- a/.ace-tasks/8r6.t.hl3-enforce-unique-ids-across-task/0-flag-collisions-in-doctor-health/8r6.t.hl3.0-flag-collisions-in-doctor-health-checks-for.s.md
+++ b/.ace-tasks/8r6.t.hl3-enforce-unique-ids-across-task/0-flag-collisions-in-doctor-health/8r6.t.hl3.0-flag-collisions-in-doctor-health-checks-for.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r6.t.hl3.0
-status: pending
+status: in-progress
 priority: medium
 created_at: "2026-04-07 11:43:34"
 estimate: TBD
@@ -54,11 +54,11 @@ Ensure `ace-task doctor` and `ace-idea doctor` make duplicate persisted IDs visi
 
 ### Success Criteria
 
-- [ ] Duplicate top-level task IDs fail `ace-task doctor`.
-- [ ] Duplicate subtask IDs fail `ace-task doctor`.
-- [ ] Duplicate idea IDs fail `ace-idea doctor`.
-- [ ] `--check frontmatter` includes duplicate-ID detection for both packages.
-- [ ] Healthy repositories retain their expected passing doctor experience.
+- [x] Duplicate top-level task IDs fail `ace-task doctor`.
+- [x] Duplicate subtask IDs fail `ace-task doctor`.
+- [x] Duplicate idea IDs fail `ace-idea doctor`.
+- [x] `--check frontmatter` includes duplicate-ID detection for both packages.
+- [x] Healthy repositories retain their expected passing doctor experience.
 
 ## Validation Questions
 

--- a/.ace-tasks/8r6.t.hl3-enforce-unique-ids-across-task/1-retry-create-when-generated-identifiers/8r6.t.hl3.1-retry-create-when-generated-identifiers-collide.s.md
+++ b/.ace-tasks/8r6.t.hl3-enforce-unique-ids-across-task/1-retry-create-when-generated-identifiers/8r6.t.hl3.1-retry-create-when-generated-identifiers-collide.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r6.t.hl3.1
-status: in-progress
+status: done
 priority: medium
 created_at: "2026-04-07 11:43:34"
 estimate: TBD

--- a/.ace-tasks/8r6.t.hl3-enforce-unique-ids-across-task/1-retry-create-when-generated-identifiers/8r6.t.hl3.1-retry-create-when-generated-identifiers-collide.s.md
+++ b/.ace-tasks/8r6.t.hl3-enforce-unique-ids-across-task/1-retry-create-when-generated-identifiers/8r6.t.hl3.1-retry-create-when-generated-identifiers-collide.s.md
@@ -1,6 +1,6 @@
 ---
 id: 8r6.t.hl3.1
-status: pending
+status: in-progress
 priority: medium
 created_at: "2026-04-07 11:43:34"
 estimate: TBD
@@ -57,12 +57,12 @@ Ensure `ace-task create` and `ace-idea create` never report a successful create 
 
 ### Success Criteria
 
-- [ ] `ace-task create` retries when a generated ID collides.
-- [ ] `ace-idea create` retries when a generated ID collides.
-- [ ] Retry exhaustion fails clearly for both packages.
-- [ ] Retry exhaustion leaves no partial task or idea artifacts behind.
-- [ ] `--dry-run` behavior remains unchanged.
-- [ ] Standard non-collision create behavior remains unchanged for both packages.
+- [x] `ace-task create` retries when a generated ID collides.
+- [x] `ace-idea create` retries when a generated ID collides.
+- [x] Retry exhaustion fails clearly for both packages.
+- [x] Retry exhaustion leaves no partial task or idea artifacts behind.
+- [x] `--dry-run` behavior remains unchanged.
+- [x] Standard non-collision create behavior remains unchanged for both packages.
 
 ## Validation Questions
 

--- a/.ace-tasks/8rc.t.k2l-fix-ace-task-plan-content/8rc.t.k2l-fix-ace-task-plan-content-stall-during.s.md
+++ b/.ace-tasks/8rc.t.k2l-fix-ace-task-plan-content/8rc.t.k2l-fix-ace-task-plan-content-stall-during.s.md
@@ -1,0 +1,11 @@
+---
+id: 8rc.t.k2l
+status: pending
+priority: medium
+created_at: "2026-04-13 13:22:54"
+estimate: 
+dependencies: []
+tags: [ace-task, planning, reliability]
+---
+
+# Fix ace-task plan --content stall during assignment task-work flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this project will be documented in this file.
 - **ace-idea v0.19.2**: Added duplicate persisted idea-ID detection to doctor health checks and made `ace-idea doctor --check frontmatter` fail when duplicates are present.
 - **ace-task v0.34.3**: Added bounded create-time ID-collision retries with clear exhaustion failures and no-orphan cleanup guarantees for standalone task creation.
 - **ace-idea v0.19.3**: Added bounded create-time ID-collision retries, enforced unique persisted idea IDs (no same-ID slug variants), and added clear exhaustion failures.
+- **ace-idea v0.20.2**: Made create-time collision retries deterministic by reusing precomputed create payloads so clipboard capture and LLM enhancement are not rerun across retry attempts.
+- **ace-task v0.35.1**: Accepted subtask IDs during frontmatter ID validation, added atomic create-time ID reservation for collision-safe retries, and narrowed ID-existence scans to ID-prefixed glob matches.
+- **ace-idea v0.20.1**: Added atomic create-time ID reservation for collision-safe retries and narrowed ID-existence scans to ID-prefixed glob matches.
 - **ace-task v0.35.0**: Added duplicate persisted task-ID detection to doctor health checks (including subtask collisions), made `ace-task doctor --check frontmatter` fail on duplicates, and added bounded standalone create-time ID-collision retries with clear exhaustion failures and no-orphan cleanup guarantees.
 - **ace-idea v0.20.0**: Added duplicate persisted idea-ID detection to doctor health checks, made frontmatter-only doctor validation fail on duplicates, and added bounded create-time ID-collision retries that enforce unique persisted IDs instead of accepting same-ID slug variants.
 - **ace-test-runner v0.24.2**: Relaxed the removed `unit` target regression assertion so the canonical-target error contract is validated without pinning output order.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - **ace-idea v0.19.2**: Added duplicate persisted idea-ID detection to doctor health checks and made `ace-idea doctor --check frontmatter` fail when duplicates are present.
 - **ace-task v0.34.3**: Added bounded create-time ID-collision retries with clear exhaustion failures and no-orphan cleanup guarantees for standalone task creation.
 - **ace-idea v0.19.3**: Added bounded create-time ID-collision retries, enforced unique persisted idea IDs (no same-ID slug variants), and added clear exhaustion failures.
+- **ace-task v0.35.0**: Added duplicate persisted task-ID detection to doctor health checks (including subtask collisions), made `ace-task doctor --check frontmatter` fail on duplicates, and added bounded standalone create-time ID-collision retries with clear exhaustion failures and no-orphan cleanup guarantees.
+- **ace-idea v0.20.0**: Added duplicate persisted idea-ID detection to doctor health checks, made frontmatter-only doctor validation fail on duplicates, and added bounded create-time ID-collision retries that enforce unique persisted IDs instead of accepting same-ID slug variants.
 - **ace-test-runner v0.24.2**: Relaxed the removed `unit` target regression assertion so the canonical-target error contract is validated without pinning output order.
 - **ace-llm v0.33.3**: Added `codex:mini` as a `commit` role fallback after `glite` so release/commit tooling can continue role-based generation when the primary model is unavailable.
 - **ace-llm v0.33.2**: Fixed provider credential availability checks so role-based selector resolution no longer crashes when only fallback environment keys are configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - **ace-llm v0.33.4**: Added the missing `ace-support-models` runtime dependency and aligned quick-start install guidance so fresh onboarding can run `ace-llm --list-providers` without manual dependency patching.
 - **ace-task v0.34.2**: Added duplicate persisted task-ID detection to doctor health checks (including subtask collisions) and made `ace-task doctor --check frontmatter` fail when duplicates are present.
 - **ace-idea v0.19.2**: Added duplicate persisted idea-ID detection to doctor health checks and made `ace-idea doctor --check frontmatter` fail when duplicates are present.
+- **ace-task v0.34.3**: Added bounded create-time ID-collision retries with clear exhaustion failures and no-orphan cleanup guarantees for standalone task creation.
+- **ace-idea v0.19.3**: Added bounded create-time ID-collision retries, enforced unique persisted idea IDs (no same-ID slug variants), and added clear exhaustion failures.
 - **ace-test-runner v0.24.2**: Relaxed the removed `unit` target regression assertion so the canonical-target error contract is validated without pinning output order.
 - **ace-llm v0.33.3**: Added `codex:mini` as a `commit` role fallback after `glite` so release/commit tooling can continue role-based generation when the primary model is unavailable.
 - **ace-llm v0.33.2**: Fixed provider credential availability checks so role-based selector resolution no longer crashes when only fallback environment keys are configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 - **ace-llm-providers-cli v0.28.4**: Filtered forwarded Claude `--max-tokens` CLI args when the local Claude CLI does not advertise support, closing the passthrough path that could still trigger unsupported-option failures.
 - **ace-llm-providers-cli v0.28.3**: Guarded Claude CLI `--max-tokens` usage so commit-generation flows skip the flag on unsupported Claude versions while preserving token limiting on supported variants.
 - **ace-llm v0.33.4**: Added the missing `ace-support-models` runtime dependency and aligned quick-start install guidance so fresh onboarding can run `ace-llm --list-providers` without manual dependency patching.
+- **ace-task v0.34.2**: Added duplicate persisted task-ID detection to doctor health checks (including subtask collisions) and made `ace-task doctor --check frontmatter` fail when duplicates are present.
+- **ace-idea v0.19.2**: Added duplicate persisted idea-ID detection to doctor health checks and made `ace-idea doctor --check frontmatter` fail when duplicates are present.
 - **ace-test-runner v0.24.2**: Relaxed the removed `unit` target regression assertion so the canonical-target error contract is validated without pinning output order.
 - **ace-llm v0.33.3**: Added `codex:mini` as a `commit` role fallback after `glite` so release/commit tooling can continue role-based generation when the primary model is unavailable.
 - **ace-llm v0.33.2**: Fixed provider credential availability checks so role-based selector resolution no longer crashes when only fallback environment keys are configured.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ PATH
 PATH
   remote: ace-idea
   specs:
-    ace-idea (0.19.3)
+    ace-idea (0.20.0)
       ace-b36ts (~> 0.13)
       ace-support-cli (~> 0.6)
       ace-support-core (~> 0.29)
@@ -336,7 +336,7 @@ PATH
 PATH
   remote: ace-task
   specs:
-    ace-task (0.34.3)
+    ace-task (0.35.0)
       ace-b36ts (~> 0.13)
       ace-git (~> 0.19)
       ace-support-cli (~> 0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ PATH
 PATH
   remote: ace-idea
   specs:
-    ace-idea (0.19.2)
+    ace-idea (0.19.3)
       ace-b36ts (~> 0.13)
       ace-support-cli (~> 0.6)
       ace-support-core (~> 0.29)
@@ -336,7 +336,7 @@ PATH
 PATH
   remote: ace-task
   specs:
-    ace-task (0.34.2)
+    ace-task (0.34.3)
       ace-b36ts (~> 0.13)
       ace-git (~> 0.19)
       ace-support-cli (~> 0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ PATH
 PATH
   remote: ace-idea
   specs:
-    ace-idea (0.19.1)
+    ace-idea (0.19.2)
       ace-b36ts (~> 0.13)
       ace-support-cli (~> 0.6)
       ace-support-core (~> 0.29)
@@ -336,7 +336,7 @@ PATH
 PATH
   remote: ace-task
   specs:
-    ace-task (0.34.1)
+    ace-task (0.34.2)
       ace-b36ts (~> 0.13)
       ace-git (~> 0.19)
       ace-support-cli (~> 0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ PATH
 PATH
   remote: ace-idea
   specs:
-    ace-idea (0.20.0)
+    ace-idea (0.20.2)
       ace-b36ts (~> 0.13)
       ace-support-cli (~> 0.6)
       ace-support-core (~> 0.29)
@@ -336,7 +336,7 @@ PATH
 PATH
   remote: ace-task
   specs:
-    ace-task (0.35.0)
+    ace-task (0.35.1)
       ace-b36ts (~> 0.13)
       ace-git (~> 0.19)
       ace-support-cli (~> 0.6)

--- a/ace-idea/CHANGELOG.md
+++ b/ace-idea/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.19.3] - 2026-04-13
+
+### Fixed
+- Added bounded retry handling for `ace-idea create` ID collisions so success is emitted only after a unique persisted idea ID exists.
+- Enforced create-time collision semantics where "same ID, different folder slug" is no longer treated as successful creation.
+- Added clear retry-exhaustion failure messaging for create-time ID collisions.
+
+### Technical
+- Updated molecule, command, and feature regression coverage to validate ID-retry semantics and no-orphan cleanup behavior.
+
 ## [0.19.2] - 2026-04-13
 
 ### Fixed

--- a/ace-idea/CHANGELOG.md
+++ b/ace-idea/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.20.0] - 2026-04-13
+
+### Fixed
+- Added duplicate persisted idea-ID detection to doctor health checks and made frontmatter-only doctor validation fail when duplicates are present.
+- Added bounded retry handling for `ace-idea create` ID collisions, including retry-exhaustion failures and enforcement that same-ID/different-slug creates are not treated as success.
+
+### Technical
+- Added regression coverage for duplicate-ID doctor failures, create-time retry semantics, and orphan-artifact cleanup guarantees.
+
 ## [0.19.3] - 2026-04-13
 
 ### Fixed

--- a/ace-idea/CHANGELOG.md
+++ b/ace-idea/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.20.2] - 2026-04-13
+
+### Fixed
+- Made create-time collision retries deterministic by reusing one precomputed payload across retries so clipboard capture and LLM enhancement are not rerun with divergent inputs.
+
+### Technical
+- Added manager-level regression coverage to enforce payload reuse semantics across collision retries.
+
+## [0.20.1] - 2026-04-13
+
+### Fixed
+- Added atomic idea-ID reservation during create so concurrent creates fail fast with retryable collision semantics instead of racing through non-atomic prechecks.
+
+### Technical
+- Narrowed idea ID-existence scans to ID-prefixed glob matches and added regression coverage for reservation-lock collision handling.
+
 ## [0.20.0] - 2026-04-13
 
 ### Fixed

--- a/ace-idea/CHANGELOG.md
+++ b/ace-idea/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.19.2] - 2026-04-13
+
+### Fixed
+- Report duplicate persisted idea IDs as explicit doctor health-check errors with file-path context.
+- Include duplicate ID detection in `ace-idea doctor --check frontmatter` and fail health status when duplicates are present.
+
+### Technical
+- Added organism and CLI regression coverage for duplicate ID failures and frontmatter-only doctor checks.
+
 ## [0.19.1] - 2026-04-13
 
 ### Changed

--- a/ace-idea/docs/usage.md
+++ b/ace-idea/docs/usage.md
@@ -3,8 +3,8 @@ doc-type: user
 title: ace-idea CLI Usage Reference
 purpose: Command reference for ace-idea
 ace-docs:
-  last-updated: 2026-03-22
-  last-checked: 2026-03-22
+  last-updated: '2026-04-13'
+  last-checked: '2026-04-13'
 ---
 
 # ace-idea CLI Usage Reference
@@ -91,6 +91,11 @@ ace-idea status --up-next-limit 5
 ### `ace-idea create [CONTENT]`
 
 Create a new idea from direct text or clipboard input.
+
+If the generated idea ID collides with an existing persisted idea, `ace-idea create`
+automatically retries with a new ID. If retries are exhausted, the command fails
+without leaving behind a partial idea artifact. A same-ID create under a different
+folder slug is treated as a collision, not a successful create.
 
 **Syntax:**
 
@@ -209,6 +214,9 @@ ace-idea update q7w --move-to archive
 ### `ace-idea doctor`
 
 Run health checks across the idea store.
+
+Duplicate persisted idea IDs are reported as errors. `ace-idea doctor --check frontmatter`
+also fails when duplicate IDs are present in idea frontmatter.
 
 **Syntax:**
 

--- a/ace-idea/lib/ace/idea/cli/commands/create.rb
+++ b/ace-idea/lib/ace/idea/cli/commands/create.rb
@@ -71,14 +71,18 @@ module Ace
             end
 
             manager = Ace::Idea::Organisms::IdeaManager.new
-            idea = manager.create(
-              content,
-              title: title,
-              tags: tags,
-              move_to: move_to,
-              clipboard: clipboard || false,
-              llm_enhance: llm_enhance || false
-            )
+            idea = begin
+              manager.create(
+                content,
+                title: title,
+                tags: tags,
+                move_to: move_to,
+                clipboard: clipboard || false,
+                llm_enhance: llm_enhance || false
+              )
+            rescue Ace::Idea::Organisms::IdeaManager::CreateRetriesExhaustedError => e
+              raise Ace::Support::Cli::Error, e.message
+            end
 
             folder_info = idea.special_folder ? " (#{idea.special_folder})" : ""
             puts "Idea created: #{idea.id} #{idea.title}#{folder_info}"

--- a/ace-idea/lib/ace/idea/molecules/idea_creator.rb
+++ b/ace-idea/lib/ace/idea/molecules/idea_creator.rb
@@ -35,77 +35,100 @@ module Ace
         # @param time [Time] Creation time (default: now)
         # @return [Idea] Created idea object
         def create(content = nil, title: nil, tags: [], move_to: nil,
-          clipboard: false, llm_enhance: false, time: Time.now.utc)
-          # Step 1: Gather content
+          clipboard: false, llm_enhance: false, time: Time.now.utc, prepared_payload: nil)
+          payload = prepared_payload || prepare_create_payload(content, clipboard: clipboard, llm_enhance: llm_enhance)
+          enhanced_body = payload.fetch(:enhanced_body)
+          attachments_to_save = payload.fetch(:attachments_to_save)
+
+          # Step 3: Generate ID and slugs
+          id = Atoms::IdeaIdFormatter.generate(time)
+          with_id_reservation(id) do
+            raise IdCollisionError, "Idea ID collision detected for #{id}" if idea_id_exists?(id)
+
+            slug_title = title || extract_title(enhanced_body)
+            folder_slug = generate_folder_slug(slug_title)
+            file_slug = generate_file_slug(slug_title)
+
+            # Step 4: Determine target directory
+            target_dir = determine_target_dir(move_to)
+            FileUtils.mkdir_p(target_dir)
+
+            # Step 5: Create idea folder
+            folder_name, _ = unique_folder_name(id, folder_slug, target_dir)
+            idea_dir = File.join(target_dir, folder_name)
+            FileUtils.mkdir_p(idea_dir)
+
+            begin
+              # Step 6: Handle attachments
+              if attachments_to_save.any?
+                enhanced_body = save_attachments_and_inject_refs(attachments_to_save, idea_dir, enhanced_body)
+              end
+
+              # Step 7: Write spec file
+              effective_title = title || extract_title(enhanced_body) || "Untitled Idea"
+              frontmatter = Atoms::IdeaFrontmatterDefaults.build(
+                id: id,
+                title: effective_title,
+                tags: tags,
+                status: "pending",
+                created_at: time
+              )
+
+              file_content = build_file_content(frontmatter, enhanced_body, effective_title)
+              spec_filename = Atoms::IdeaFilePattern.spec_filename(id, file_slug)
+              spec_file = File.join(idea_dir, spec_filename)
+              File.write(spec_file, file_content)
+
+              # Step 8: Load and return the created idea
+              loader = IdeaLoader.new
+              special_folder = Ace::Support::Items::Atoms::SpecialFolderDetector.detect_in_path(
+                idea_dir, root: @root_dir
+              )
+              loader.load(idea_dir, id: id, special_folder: special_folder)
+            rescue StandardError
+              FileUtils.rm_rf(idea_dir) if Dir.exist?(idea_dir)
+              raise
+            end
+          end
+        end
+
+        def prepare_create_payload(content, clipboard: false, llm_enhance: false)
           body, attachments_to_save = gather_content(content, clipboard: clipboard)
 
           if body.nil? || body.strip.empty?
             raise ArgumentError, "No content provided. Provide text or use --clipboard."
           end
 
-          # Step 2: Optionally enhance with LLM
           enhanced_body = if llm_enhance
             enhance_with_llm(body, config: @config)
           else
             body
           end
 
-          # Step 3: Generate ID and slugs
-          id = Atoms::IdeaIdFormatter.generate(time)
-          raise IdCollisionError, "Idea ID collision detected for #{id}" if idea_id_exists?(id)
-          slug_title = title || extract_title(enhanced_body)
-          folder_slug = generate_folder_slug(slug_title)
-          file_slug = generate_file_slug(slug_title)
-
-          # Step 4: Determine target directory
-          target_dir = determine_target_dir(move_to)
-          FileUtils.mkdir_p(target_dir)
-
-          # Step 5: Create idea folder
-          folder_name, _ = unique_folder_name(id, folder_slug, target_dir)
-          idea_dir = File.join(target_dir, folder_name)
-          FileUtils.mkdir_p(idea_dir)
-
-          begin
-            # Step 6: Handle attachments
-            if attachments_to_save.any?
-              enhanced_body = save_attachments_and_inject_refs(attachments_to_save, idea_dir, enhanced_body)
-            end
-
-            # Step 7: Write spec file
-            effective_title = title || extract_title(enhanced_body) || "Untitled Idea"
-            frontmatter = Atoms::IdeaFrontmatterDefaults.build(
-              id: id,
-              title: effective_title,
-              tags: tags,
-              status: "pending",
-              created_at: time
-            )
-
-            file_content = build_file_content(frontmatter, enhanced_body, effective_title)
-            spec_filename = Atoms::IdeaFilePattern.spec_filename(id, file_slug)
-            spec_file = File.join(idea_dir, spec_filename)
-            File.write(spec_file, file_content)
-
-            # Step 8: Load and return the created idea
-            loader = IdeaLoader.new
-            special_folder = Ace::Support::Items::Atoms::SpecialFolderDetector.detect_in_path(
-              idea_dir, root: @root_dir
-            )
-            loader.load(idea_dir, id: id, special_folder: special_folder)
-          rescue StandardError
-            FileUtils.rm_rf(idea_dir) if Dir.exist?(idea_dir)
-            raise
-          end
+          {
+            enhanced_body: enhanced_body,
+            attachments_to_save: attachments_to_save
+          }
         end
 
         private
 
         def idea_id_exists?(id)
-          escaped = Regexp.escape(id)
-          Dir.glob(File.join(@root_dir, "**", "*")).any? do |path|
-            File.directory?(path) && File.basename(path).match?(/\A#{escaped}-/)
+          Dir.glob(File.join(@root_dir, "**", "#{id}-*")).any? do |path|
+            File.directory?(path)
           end
+        end
+
+        def with_id_reservation(id)
+          reservation_path = File.join(@root_dir, ".ace-idea-id-lock-#{id}")
+          acquired = false
+          Dir.mkdir(reservation_path)
+          acquired = true
+          yield
+        rescue Errno::EEXIST
+          raise IdCollisionError, "Idea ID collision detected for #{id}"
+        ensure
+          FileUtils.rm_rf(reservation_path) if acquired && reservation_path && Dir.exist?(reservation_path)
         end
 
         def gather_content(content, clipboard: false)

--- a/ace-idea/lib/ace/idea/molecules/idea_creator.rb
+++ b/ace-idea/lib/ace/idea/molecules/idea_creator.rb
@@ -16,6 +16,8 @@ module Ace
       # Creates new ideas with b36ts IDs, folder/file creation.
       # Supports --clipboard, --llm-enhance, and --move-to options.
       class IdeaCreator
+        class IdCollisionError < StandardError; end
+
         # @param root_dir [String] Root directory for ideas
         # @param config [Hash] Configuration hash
         def initialize(root_dir:, config: {})
@@ -50,6 +52,7 @@ module Ace
 
           # Step 3: Generate ID and slugs
           id = Atoms::IdeaIdFormatter.generate(time)
+          raise IdCollisionError, "Idea ID collision detected for #{id}" if idea_id_exists?(id)
           slug_title = title || extract_title(enhanced_body)
           folder_slug = generate_folder_slug(slug_title)
           file_slug = generate_file_slug(slug_title)
@@ -58,40 +61,52 @@ module Ace
           target_dir = determine_target_dir(move_to)
           FileUtils.mkdir_p(target_dir)
 
-          # Step 5: Create idea folder (ensure unique name if ID collision occurs)
+          # Step 5: Create idea folder
           folder_name, _ = unique_folder_name(id, folder_slug, target_dir)
           idea_dir = File.join(target_dir, folder_name)
           FileUtils.mkdir_p(idea_dir)
 
-          # Step 6: Handle attachments
-          if attachments_to_save.any?
-            enhanced_body = save_attachments_and_inject_refs(attachments_to_save, idea_dir, enhanced_body)
+          begin
+            # Step 6: Handle attachments
+            if attachments_to_save.any?
+              enhanced_body = save_attachments_and_inject_refs(attachments_to_save, idea_dir, enhanced_body)
+            end
+
+            # Step 7: Write spec file
+            effective_title = title || extract_title(enhanced_body) || "Untitled Idea"
+            frontmatter = Atoms::IdeaFrontmatterDefaults.build(
+              id: id,
+              title: effective_title,
+              tags: tags,
+              status: "pending",
+              created_at: time
+            )
+
+            file_content = build_file_content(frontmatter, enhanced_body, effective_title)
+            spec_filename = Atoms::IdeaFilePattern.spec_filename(id, file_slug)
+            spec_file = File.join(idea_dir, spec_filename)
+            File.write(spec_file, file_content)
+
+            # Step 8: Load and return the created idea
+            loader = IdeaLoader.new
+            special_folder = Ace::Support::Items::Atoms::SpecialFolderDetector.detect_in_path(
+              idea_dir, root: @root_dir
+            )
+            loader.load(idea_dir, id: id, special_folder: special_folder)
+          rescue StandardError
+            FileUtils.rm_rf(idea_dir) if Dir.exist?(idea_dir)
+            raise
           end
-
-          # Step 7: Write spec file
-          effective_title = title || extract_title(enhanced_body) || "Untitled Idea"
-          frontmatter = Atoms::IdeaFrontmatterDefaults.build(
-            id: id,
-            title: effective_title,
-            tags: tags,
-            status: "pending",
-            created_at: time
-          )
-
-          file_content = build_file_content(frontmatter, enhanced_body, effective_title)
-          spec_filename = Atoms::IdeaFilePattern.spec_filename(id, file_slug)
-          spec_file = File.join(idea_dir, spec_filename)
-          File.write(spec_file, file_content)
-
-          # Step 8: Load and return the created idea
-          loader = IdeaLoader.new
-          special_folder = Ace::Support::Items::Atoms::SpecialFolderDetector.detect_in_path(
-            idea_dir, root: @root_dir
-          )
-          loader.load(idea_dir, id: id, special_folder: special_folder)
         end
 
         private
+
+        def idea_id_exists?(id)
+          escaped = Regexp.escape(id)
+          Dir.glob(File.join(@root_dir, "**", "*")).any? do |path|
+            File.directory?(path) && File.basename(path).match?(/\A#{escaped}-/)
+          end
+        end
 
         def gather_content(content, clipboard: false)
           attachments = []

--- a/ace-idea/lib/ace/idea/organisms/idea_doctor.rb
+++ b/ace-idea/lib/ace/idea/organisms/idea_doctor.rb
@@ -117,10 +117,17 @@ module Ace
 
           scan_results = scanner.scan
           @stats[:ideas_scanned] = scan_results.size
+          id_locations = Hash.new { |hash, key| hash[key] = [] }
 
           scan_results.each do |scan_result|
             spec_file = scan_result.file_path
             next unless spec_file && File.exist?(spec_file)
+
+            content = File.read(spec_file)
+            frontmatter, _body = Ace::Support::Items::Atoms::FrontmatterParser.parse(content)
+            if frontmatter.is_a?(Hash) && frontmatter["id"] && !frontmatter["id"].to_s.strip.empty?
+              id_locations[frontmatter["id"]] << spec_file
+            end
 
             issues = Molecules::IdeaFrontmatterValidator.validate(
               spec_file,
@@ -134,6 +141,8 @@ module Ace
               add_issue(issue[:type], issue[:message], issue[:location])
             end
           end
+
+          add_duplicate_id_issues(id_locations)
         end
 
         def run_scope_check
@@ -181,6 +190,18 @@ module Ace
             end
           end
           count
+        end
+
+        def add_duplicate_id_issues(id_locations)
+          id_locations.each do |id, locations|
+            next unless locations.size > 1
+
+            add_issue(
+              :error,
+              "Duplicate idea ID '#{id}' found in: #{locations.sort.join(', ')}",
+              locations.first
+            )
+          end
         end
 
         def add_issue(type, message, location = nil)

--- a/ace-idea/lib/ace/idea/organisms/idea_manager.rb
+++ b/ace-idea/lib/ace/idea/organisms/idea_manager.rb
@@ -39,12 +39,25 @@ module Ace
           clipboard: false, llm_enhance: false)
           ensure_root_dir
           creator = Molecules::IdeaCreator.new(root_dir: @root_dir, config: @config)
+          prepared_payload = creator.prepare_create_payload(
+            content,
+            clipboard: clipboard,
+            llm_enhance: llm_enhance
+          )
           attempts = 0
 
           begin
             attempts += 1
-            creator.create(content, title: title, tags: tags, move_to: move_to,
-              clipboard: clipboard, llm_enhance: llm_enhance, time: Time.now.utc + ((attempts - 1) * 2))
+            creator.create(
+              nil,
+              title: title,
+              tags: tags,
+              move_to: move_to,
+              clipboard: false,
+              llm_enhance: false,
+              time: Time.now.utc + ((attempts - 1) * 2),
+              prepared_payload: prepared_payload
+            )
           rescue Molecules::IdeaCreator::IdCollisionError
             retry if attempts < CREATE_RETRY_LIMIT
             raise CreateRetriesExhaustedError,

--- a/ace-idea/lib/ace/idea/organisms/idea_manager.rb
+++ b/ace-idea/lib/ace/idea/organisms/idea_manager.rb
@@ -15,6 +15,9 @@ module Ace
       # Orchestrates all idea CRUD operations.
       # Entry point for idea management with config-driven root directory.
       class IdeaManager
+        CREATE_RETRY_LIMIT = 3
+        class CreateRetriesExhaustedError < StandardError; end
+
         attr_reader :last_list_total, :last_folder_counts
 
         # @param root_dir [String, nil] Override root directory for ideas
@@ -36,8 +39,17 @@ module Ace
           clipboard: false, llm_enhance: false)
           ensure_root_dir
           creator = Molecules::IdeaCreator.new(root_dir: @root_dir, config: @config)
-          creator.create(content, title: title, tags: tags, move_to: move_to,
-            clipboard: clipboard, llm_enhance: llm_enhance)
+          attempts = 0
+
+          begin
+            attempts += 1
+            creator.create(content, title: title, tags: tags, move_to: move_to,
+              clipboard: clipboard, llm_enhance: llm_enhance, time: Time.now.utc + ((attempts - 1) * 2))
+          rescue Molecules::IdeaCreator::IdCollisionError
+            retry if attempts < CREATE_RETRY_LIMIT
+            raise CreateRetriesExhaustedError,
+              "Failed to create idea: unable to generate a unique ID after #{CREATE_RETRY_LIMIT} attempts"
+          end
         end
 
         # Create an idea from clipboard

--- a/ace-idea/lib/ace/idea/version.rb
+++ b/ace-idea/lib/ace/idea/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Idea
-    VERSION = '0.19.3'
+    VERSION = '0.20.0'
   end
 end

--- a/ace-idea/lib/ace/idea/version.rb
+++ b/ace-idea/lib/ace/idea/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Idea
-    VERSION = '0.19.1'
+    VERSION = '0.19.2'
   end
 end

--- a/ace-idea/lib/ace/idea/version.rb
+++ b/ace-idea/lib/ace/idea/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Idea
-    VERSION = '0.20.0'
+    VERSION = '0.20.2'
   end
 end

--- a/ace-idea/lib/ace/idea/version.rb
+++ b/ace-idea/lib/ace/idea/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Idea
-    VERSION = '0.19.2'
+    VERSION = '0.19.3'
   end
 end

--- a/ace-idea/test/fast/commands/idea_cli_test.rb
+++ b/ace-idea/test/fast/commands/idea_cli_test.rb
@@ -108,6 +108,62 @@ class IdeaCliTest < AceIdeaTestCase
     end
   end
 
+  def test_create_retries_when_generated_id_collides
+    with_ideas_dir do |root|
+      existing_id = "8ppq7w"
+      existing_dir = File.join(root, "#{existing_id}-existing-idea")
+      FileUtils.mkdir_p(existing_dir)
+      File.write(
+        File.join(existing_dir, "#{existing_id}-existing-idea.idea.s.md"),
+        "---\nid: #{existing_id}\nstatus: pending\n---\n\n# Existing idea\n"
+      )
+
+      ids = [existing_id, "8ppq7x"]
+      idx = 0
+      generator = lambda do |_time = nil|
+        value = ids[[idx, ids.length - 1].min]
+        idx += 1
+        value
+      end
+
+      with_cli_root(root) do
+        result = nil
+        Ace::Idea::Atoms::IdeaIdFormatter.stub(:generate, generator) do
+          result = run_cli(["create", "Retry create idea"])
+        end
+
+        assert_equal 0, result[:exit_code], result[:stderr]
+        assert_match(/Idea created: 8ppq7x/, result[:stdout])
+        created_dirs = Dir.glob(File.join(root, "8ppq7x-*"))
+        assert_equal 1, created_dirs.length
+      end
+    end
+  end
+
+  def test_create_fails_clearly_when_collision_retries_exhausted
+    with_ideas_dir do |root|
+      existing_id = "8ppq7w"
+      existing_dir = File.join(root, "#{existing_id}-existing-idea")
+      FileUtils.mkdir_p(existing_dir)
+      File.write(
+        File.join(existing_dir, "#{existing_id}-existing-idea.idea.s.md"),
+        "---\nid: #{existing_id}\nstatus: pending\n---\n\n# Existing idea\n"
+      )
+
+      with_cli_root(root) do
+        result = nil
+        Ace::Idea::Atoms::IdeaIdFormatter.stub(:generate, existing_id) do
+          result = run_cli(["create", "Will fail after retries"])
+        end
+
+        assert_equal 1, result[:exit_code]
+        assert_match(/unable to generate a unique ID after 3 attempts/i, result[:stderr])
+        colliding_dirs = Dir.glob(File.join(root, "#{existing_id}-*"))
+        assert_equal 1, colliding_dirs.length, "Expected no extra artifacts for exhausted retries"
+      end
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # show command
   # ---------------------------------------------------------------------------

--- a/ace-idea/test/fast/commands/idea_doctor_cli_test.rb
+++ b/ace-idea/test/fast/commands/idea_doctor_cli_test.rb
@@ -157,6 +157,21 @@ class IdeaDoctorCliTest < AceIdeaTestCase
     end
   end
 
+  def test_doctor_check_frontmatter_fails_on_duplicate_ids
+    with_ideas_dir do |root|
+      create_idea_fixture(root, id: "abc123", slug: "idea-one", status: "pending", tags: ["test"])
+      create_idea_fixture(root, id: "abc123", slug: "idea-two", status: "pending", tags: ["test"])
+
+      with_cli_root(root) do
+        result = run_cli(["doctor", "--check", "frontmatter"])
+        assert_equal 1, result[:exit_code]
+        assert_includes result[:stdout], "Duplicate idea ID 'abc123'"
+        assert_includes result[:stdout], "idea-one"
+        assert_includes result[:stdout], "idea-two"
+      end
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # --errors-only
   # ---------------------------------------------------------------------------
@@ -225,6 +240,19 @@ class IdeaDoctorCliTest < AceIdeaTestCase
       result = run_cli(["doctor"])
       assert_equal 1, result[:exit_code]
       assert_includes result[:stderr], "not found"
+    end
+  end
+
+  def test_doctor_fails_on_duplicate_ids
+    with_ideas_dir do |root|
+      create_idea_fixture(root, id: "abc123", slug: "idea-one", status: "pending", tags: ["test"])
+      create_idea_fixture(root, id: "abc123", slug: "idea-two", status: "pending", tags: ["test"])
+
+      with_cli_root(root) do
+        result = run_cli(["doctor"])
+        assert_equal 1, result[:exit_code]
+        assert_includes result[:stdout], "Duplicate idea ID 'abc123'"
+      end
     end
   end
 end

--- a/ace-idea/test/fast/molecules/idea_creator_test.rb
+++ b/ace-idea/test/fast/molecules/idea_creator_test.rb
@@ -169,6 +169,25 @@ class IdeaCreatorTest < AceIdeaTestCase
     end
   end
 
+  def test_raises_id_collision_when_id_reservation_is_already_held
+    with_ideas_dir do |root|
+      colliding_id = "8ppq7z"
+      reservation = File.join(root, ".ace-idea-id-lock-#{colliding_id}")
+      Dir.mkdir(reservation)
+      creator = Ace::Idea::Molecules::IdeaCreator.new(root_dir: root)
+
+      Ace::Idea::Atoms::IdeaIdFormatter.stub(:generate, colliding_id) do
+        assert_raises(Ace::Idea::Molecules::IdeaCreator::IdCollisionError) do
+          creator.create("New idea while lock is held")
+        end
+      end
+
+      assert Dir.exist?(reservation), "Expected existing reservation lock to remain untouched"
+    ensure
+      FileUtils.rm_rf(reservation) if reservation && Dir.exist?(reservation)
+    end
+  end
+
   def test_cleans_up_partial_artifacts_when_create_fails_after_write
     with_ideas_dir do |root|
       creator = Ace::Idea::Molecules::IdeaCreator.new(root_dir: root)

--- a/ace-idea/test/fast/molecules/idea_creator_test.rb
+++ b/ace-idea/test/fast/molecules/idea_creator_test.rb
@@ -149,4 +149,42 @@ class IdeaCreatorTest < AceIdeaTestCase
       assert Dir.exist?(idea.path)
     end
   end
+
+  def test_raises_id_collision_when_generated_idea_id_already_exists
+    with_ideas_dir do |root|
+      existing_id = "8ppq7w"
+      existing_dir = File.join(root, "#{existing_id}-existing-idea")
+      FileUtils.mkdir_p(existing_dir)
+      File.write(
+        File.join(existing_dir, "#{existing_id}-existing-idea.idea.s.md"),
+        "---\nid: #{existing_id}\nstatus: pending\n---\n\n# Existing idea\n"
+      )
+
+      creator = Ace::Idea::Molecules::IdeaCreator.new(root_dir: root)
+      Ace::Idea::Atoms::IdeaIdFormatter.stub(:generate, existing_id) do
+        assert_raises(Ace::Idea::Molecules::IdeaCreator::IdCollisionError) do
+          creator.create("New idea with colliding id")
+        end
+      end
+    end
+  end
+
+  def test_cleans_up_partial_artifacts_when_create_fails_after_write
+    with_ideas_dir do |root|
+      creator = Ace::Idea::Molecules::IdeaCreator.new(root_dir: root)
+      failing_loader = Object.new
+      failing_loader.define_singleton_method(:load) do |_path, id:, special_folder:|
+        raise "simulated load failure for #{id} in #{special_folder}"
+      end
+
+      Ace::Idea::Atoms::IdeaIdFormatter.stub(:generate, "8ppq7x") do
+        Ace::Idea::Molecules::IdeaLoader.stub(:new, failing_loader) do
+          assert_raises(RuntimeError) { creator.create("Idea with failing load") }
+        end
+      end
+
+      created_paths = Dir.glob(File.join(root, "8ppq7x-*"))
+      assert_empty created_paths, "Expected partial idea artifacts to be cleaned up"
+    end
+  end
 end

--- a/ace-idea/test/fast/organisms/idea_doctor_test.rb
+++ b/ace-idea/test/fast/organisms/idea_doctor_test.rb
@@ -177,6 +177,22 @@ class IdeaDoctorTest < AceIdeaTestCase
     end
   end
 
+  def test_specific_check_frontmatter_detects_duplicate_idea_ids
+    with_ideas_dir do |root|
+      create_idea_fixture(root, id: "abc123", slug: "idea-one")
+      create_idea_fixture(root, id: "abc123", slug: "idea-two")
+
+      doctor = Doctor.new(root, check: "frontmatter")
+      results = doctor.run_diagnosis
+
+      refute results[:valid]
+      duplicate_issue = results[:issues].find { |issue| issue[:message].include?("Duplicate idea ID 'abc123'") }
+      refute_nil duplicate_issue
+      assert_includes duplicate_issue[:message], "idea-one"
+      assert_includes duplicate_issue[:message], "idea-two"
+    end
+  end
+
   def test_specific_check_structure
     with_ideas_dir do |root|
       create_idea_fixture(root, id: "abc123", slug: "test-idea")
@@ -265,6 +281,22 @@ class IdeaDoctorTest < AceIdeaTestCase
       doctor = Doctor.new(root)
       results = doctor.run_diagnosis
       assert_equal root, results[:root_path]
+    end
+  end
+
+  def test_detects_duplicate_idea_ids
+    with_ideas_dir do |root|
+      create_idea_fixture(root, id: "abc123", slug: "idea-one")
+      create_idea_fixture(root, id: "abc123", slug: "idea-two")
+
+      doctor = Doctor.new(root)
+      results = doctor.run_diagnosis
+
+      refute results[:valid]
+      duplicate_issue = results[:issues].find { |issue| issue[:message].include?("Duplicate idea ID 'abc123'") }
+      refute_nil duplicate_issue
+      assert_includes duplicate_issue[:message], "idea-one"
+      assert_includes duplicate_issue[:message], "idea-two"
     end
   end
 end

--- a/ace-idea/test/fast/organisms/idea_manager_test.rb
+++ b/ace-idea/test/fast/organisms/idea_manager_test.rb
@@ -165,4 +165,44 @@ class IdeaManagerTest < AceIdeaTestCase
       assert_kind_of Array, result
     end
   end
+
+  def test_create_retries_reuse_prepared_payload_without_reprocessing_input
+    with_ideas_dir do |root|
+      manager = Ace::Idea::Organisms::IdeaManager.new(root_dir: root)
+      creator = Object.new
+      prepared_calls = 0
+      prepared_args = nil
+      create_calls = []
+      payload = {enhanced_body: "captured-body", attachments_to_save: []}
+      created_idea = Struct.new(:id).new("8ppq7z")
+
+      creator.define_singleton_method(:prepare_create_payload) do |content, clipboard:, llm_enhance:|
+        prepared_calls += 1
+        prepared_args = {content: content, clipboard: clipboard, llm_enhance: llm_enhance}
+        payload
+      end
+
+      creator.define_singleton_method(:create) do |content, **kwargs|
+        create_calls << {content: content, kwargs: kwargs}
+        raise Ace::Idea::Molecules::IdeaCreator::IdCollisionError if create_calls.length == 1
+
+        created_idea
+      end
+
+      Ace::Idea::Molecules::IdeaCreator.stub(:new, creator) do
+        result = manager.create("Initial content", clipboard: true, llm_enhance: true)
+        assert_equal created_idea, result
+      end
+
+      assert_equal 1, prepared_calls
+      assert_equal({content: "Initial content", clipboard: true, llm_enhance: true}, prepared_args)
+      assert_equal 2, create_calls.length
+      create_calls.each do |call|
+        assert_nil call[:content]
+        assert_equal false, call[:kwargs][:clipboard]
+        assert_equal false, call[:kwargs][:llm_enhance]
+        assert_equal payload, call[:kwargs][:prepared_payload]
+      end
+    end
+  end
 end

--- a/ace-idea/test/feat/idea_lifecycle_feature_test.rb
+++ b/ace-idea/test/feat/idea_lifecycle_feature_test.rb
@@ -192,51 +192,61 @@ class IdeaLifecycleFeatureTest < AceIdeaTestCase
   # 4. Concurrent creation: two ideas within the same 2-second b36ts window
   # ---------------------------------------------------------------------------
 
-  def test_concurrent_ideas_same_b36ts_id_same_slug_creates_unique_folders
+  def test_concurrent_ideas_same_b36ts_id_same_slug_retries_to_unique_id
     with_ideas_dir do |root|
-      # Fix time so both ideas get the same b36ts ID
-      fixed_time = Time.at(1706443200).utc
+      manager = Ace::Idea::Organisms::IdeaManager.new(root_dir: root)
+      ids = %w[80ri00 80ri00 80ri01]
+      idx = 0
+      generator = lambda do |_time = nil|
+        value = ids[[idx, ids.length - 1].min]
+        idx += 1
+        value
+      end
 
-      creator = Ace::Idea::Molecules::IdeaCreator.new(root_dir: root)
+      idea1 = nil
+      idea2 = nil
+      Ace::Idea::Atoms::IdeaIdFormatter.stub(:generate, generator) do
+        idea1 = manager.create("Duplicate idea content")
+        idea2 = manager.create("Duplicate idea content")
+      end
 
-      # Both ideas have same content → same slug → same potential folder name
-      idea1 = creator.create("Duplicate idea content", time: fixed_time)
-      idea2 = creator.create("Duplicate idea content", time: fixed_time)
-
-      # Both should be created without raising
       refute_nil idea1
       refute_nil idea2
-
-      # Both should have the same ID (same b36ts timestamp)
-      assert_equal idea1.id, idea2.id
-
-      # But they should be in DIFFERENT directories
-      refute_equal idea1.path, idea2.path, "Duplicate ideas must have unique folders"
-
-      # Both folders should exist on disk
+      refute_equal idea1.id, idea2.id, "Second create should retry to a unique ID"
+      assert_equal "80ri00", idea1.id
+      assert_equal "80ri01", idea2.id
       assert Dir.exist?(idea1.path), "First idea folder should exist"
       assert Dir.exist?(idea2.path), "Second idea folder should exist"
-
-      # Both spec files should exist
       assert File.exist?(idea1.file_path)
       assert File.exist?(idea2.file_path)
     end
   end
 
-  def test_concurrent_ideas_same_b36ts_id_different_slugs_are_both_accessible
+  def test_concurrent_ideas_same_b36ts_id_different_slugs_retry_to_unique_ids
     with_ideas_dir do |root|
-      fixed_time = Time.at(1706443200).utc
+      manager = Ace::Idea::Organisms::IdeaManager.new(root_dir: root)
+      ids = %w[80ri00 80ri00 80ri02]
+      idx = 0
+      generator = lambda do |_time = nil|
+        value = ids[[idx, ids.length - 1].min]
+        idx += 1
+        value
+      end
 
-      creator = Ace::Idea::Molecules::IdeaCreator.new(root_dir: root)
-
-      idea1 = creator.create("First concurrent idea", time: fixed_time)
-      idea2 = creator.create("Second concurrent idea", time: fixed_time)
+      idea1 = nil
+      idea2 = nil
+      Ace::Idea::Atoms::IdeaIdFormatter.stub(:generate, generator) do
+        idea1 = manager.create("First concurrent idea")
+        idea2 = manager.create("Second concurrent idea")
+      end
 
       refute_nil idea1
       refute_nil idea2
 
-      # Both created successfully with same ID but different slugs
-      assert_equal idea1.id, idea2.id
+      # Collision is retried; final persisted IDs are unique.
+      refute_equal idea1.id, idea2.id
+      assert_equal "80ri00", idea1.id
+      assert_equal "80ri02", idea2.id
 
       # Both accessible through the file system
       assert Dir.exist?(idea1.path)

--- a/ace-task/CHANGELOG.md
+++ b/ace-task/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.34.2] - 2026-04-13
+
+### Fixed
+- Report duplicate persisted task IDs as explicit doctor health-check errors with file-path context, including top-level and subtask collisions.
+- Include duplicate ID detection in `ace-task doctor --check frontmatter` and fail health status when duplicates are present.
+
+### Technical
+- Added organism and CLI regression coverage for duplicate top-level/subtask ID failures and frontmatter-only doctor checks.
+
 ## [0.34.1] - 2026-04-13
 
 ### Changed

--- a/ace-task/CHANGELOG.md
+++ b/ace-task/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.35.0] - 2026-04-13
+
+### Fixed
+- Added duplicate persisted task-ID detection to doctor health checks, including subtask collisions and frontmatter-only doctor validation failures.
+- Added bounded retry handling for standalone `ace-task create` ID collisions with clear retry-exhaustion failures and no partial-artifact leakage.
+
+### Technical
+- Added regression coverage for duplicate-ID doctor failures, create-time retry semantics, and cleanup guarantees.
+
 ## [0.34.3] - 2026-04-13
 
 ### Fixed

--- a/ace-task/CHANGELOG.md
+++ b/ace-task/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.34.3] - 2026-04-13
+
+### Fixed
+- Added bounded retry handling for standalone `ace-task create` ID collisions so success is emitted only after a unique persisted task ID exists.
+- Added clear retry-exhaustion failure messaging for create-time ID collisions.
+
+### Technical
+- Added command and molecule regression coverage for task ID collision retries and partial-artifact cleanup guarantees.
+
 ## [0.34.2] - 2026-04-13
 
 ### Fixed

--- a/ace-task/CHANGELOG.md
+++ b/ace-task/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.35.1] - 2026-04-13
+
+### Fixed
+- Accepted subtask IDs in task frontmatter ID validation so doctor frontmatter checks no longer report false invalid-ID errors for valid subtasks.
+- Added atomic task-ID reservation during create so concurrent creates treat lock contention as retryable collisions instead of racing through non-atomic prechecks.
+
+### Technical
+- Narrowed task ID-existence scans to ID-prefixed glob matches and added regression coverage for subtask ID validation plus reservation-lock collision behavior.
+
 ## [0.35.0] - 2026-04-13
 
 ### Fixed

--- a/ace-task/docs/demo/ace-task-subtask-frontmatter.tape.yml
+++ b/ace-task/docs/demo/ace-task-subtask-frontmatter.tape.yml
@@ -1,0 +1,27 @@
+---
+description: Demonstrate frontmatter doctor check accepting valid subtask IDs
+tags:
+- ace-task
+- docs
+- doctor
+- subtask
+settings:
+  font_size: 16
+  width: 960
+  height: 540
+  format: gif
+scenes:
+- name: Show parent task and subtask tree
+  commands:
+  - type: ace-task show q7w --tree
+    sleep: 4s
+- name: Run frontmatter health check
+  commands:
+  - type: ace-task doctor --check frontmatter
+    sleep: 4s
+teardown:
+- cleanup
+setup:
+- sandbox
+- copy-fixtures
+- git-init

--- a/ace-task/docs/demo/fixtures/.ace-tasks/8pp.t.q7w-parent/0-subtask/8pp.t.q7w.0-subtask.s.md
+++ b/ace-task/docs/demo/fixtures/.ace-tasks/8pp.t.q7w-parent/0-subtask/8pp.t.q7w.0-subtask.s.md
@@ -1,0 +1,10 @@
+---
+id: 8pp.t.q7w.0
+parent: 8pp.t.q7w
+status: pending
+title: Subtask with valid subtask ID
+created_at: 2026-04-13T00:00:00Z
+tags: [demo]
+---
+
+# Subtask with valid subtask ID

--- a/ace-task/docs/demo/fixtures/.ace-tasks/8pp.t.q7w-parent/8pp.t.q7w-parent.s.md
+++ b/ace-task/docs/demo/fixtures/.ace-tasks/8pp.t.q7w-parent/8pp.t.q7w-parent.s.md
@@ -1,0 +1,9 @@
+---
+id: 8pp.t.q7w
+status: pending
+title: Parent task for doctor validation
+created_at: 2026-04-13T00:00:00Z
+tags: [demo]
+---
+
+# Parent task for doctor validation

--- a/ace-task/docs/usage.md
+++ b/ace-task/docs/usage.md
@@ -2,7 +2,8 @@
 doc-type: user
 purpose: CLI reference for ace-task commands and options
 ace-docs:
-  last-updated: '2026-03-21'
+  last-updated: '2026-04-13'
+  last-checked: '2026-04-13'
 ---
 
 # ace-task CLI Reference
@@ -45,6 +46,10 @@ github_issue: 276
 ### ace-task create TITLE
 
 Create a new task with a B36TS-based ID.
+
+If the generated task ID collides with an existing persisted task, `ace-task create`
+automatically retries with a new ID. If it cannot obtain a unique ID within the retry
+budget, the command fails cleanly without leaving behind a partial task artifact.
 
 | Option | Alias | Description |
 |--------|-------|-------------|
@@ -188,6 +193,10 @@ ace-task github-sync --all
 ### ace-task doctor
 
 Run health checks on tasks. Validates frontmatter, file structure, and scope/status consistency.
+
+Duplicate persisted task IDs are reported as errors, including subtask collisions.
+`ace-task doctor --check frontmatter` also fails when duplicate IDs are present in
+task frontmatter.
 
 | Option | Alias | Description |
 |--------|-------|-------------|

--- a/ace-task/lib/ace/task/atoms/task_validation_rules.rb
+++ b/ace-task/lib/ace/task/atoms/task_validation_rules.rb
@@ -19,7 +19,7 @@ module Ace
         end
 
         def self.valid_id?(id)
-          id.to_s.match?(/^[0-9a-z]{3}\.[a-z]\.[0-9a-z]{3}$/)
+          id.to_s.match?(/\A[0-9a-z]{3}\.[a-z]\.[0-9a-z]{3}(?:\.[0-9a-z])?\z/)
         end
 
         def self.scope_consistent?(status, special_folder)

--- a/ace-task/lib/ace/task/cli/commands/create.rb
+++ b/ace-task/lib/ace/task/cli/commands/create.rb
@@ -76,25 +76,29 @@ module Ace
 
             manager = Ace::Task::Organisms::TaskManager.new
 
-            task = if child_of
-              manager.create_subtask(
-                child_of,
-                title,
-                status: status,
-                priority: priority,
-                tags: tags,
-                estimate: estimate,
-                github_issue: github_issue
-              )
-            else
-              manager.create(
-                title,
-                status: status,
-                priority: priority,
-                tags: tags,
-                estimate: estimate,
-                github_issue: github_issue
-              )
+            task = begin
+              if child_of
+                manager.create_subtask(
+                  child_of,
+                  title,
+                  status: status,
+                  priority: priority,
+                  tags: tags,
+                  estimate: estimate,
+                  github_issue: github_issue
+                )
+              else
+                manager.create(
+                  title,
+                  status: status,
+                  priority: priority,
+                  tags: tags,
+                  estimate: estimate,
+                  github_issue: github_issue
+                )
+              end
+            rescue Ace::Task::Organisms::TaskManager::CreateRetriesExhaustedError => e
+              raise Ace::Support::Cli::Error, e.message
             end
 
             unless task

--- a/ace-task/lib/ace/task/molecules/task_creator.rb
+++ b/ace-task/lib/ace/task/molecules/task_creator.rb
@@ -47,58 +47,72 @@ module Ace
           # Generate task ID
           item_id = Atoms::TaskIdFormatter.generate(time)
           formatted_id = item_id.formatted_id
-          raise IdCollisionError, "Task ID collision detected for #{formatted_id}" if task_id_exists?(formatted_id)
 
-          # Generate slugs
-          slugs = if use_llm_slug
-            generate_llm_slugs(title) || generate_slugs(title)
-          else
-            generate_slugs(title)
-          end
-          folder_slug = slugs[:folder]
-          file_slug = slugs[:file]
+          with_id_reservation(formatted_id) do
+            raise IdCollisionError, "Task ID collision detected for #{formatted_id}" if task_id_exists?(formatted_id)
 
-          # Create folder with folder_slug
-          folder_name = Atoms::TaskIdFormatter.folder_name(formatted_id, folder_slug)
-          task_dir = File.join(@root_dir, folder_name)
-          FileUtils.mkdir_p(task_dir)
+            # Generate slugs
+            slugs = if use_llm_slug
+              generate_llm_slugs(title) || generate_slugs(title)
+            else
+              generate_slugs(title)
+            end
+            folder_slug = slugs[:folder]
+            file_slug = slugs[:file]
 
-          begin
-            # Build frontmatter with all fields
-            effective_status = status || @config.dig("task", "default_status") || "pending"
-            frontmatter = Atoms::TaskFrontmatterDefaults.build(
-              id: formatted_id,
-              status: effective_status,
-              priority: priority,
-              tags: tags,
-              dependencies: dependencies,
-              created_at: time,
-              estimate: estimate,
-              github_issue: github_issue
-            )
+            # Create folder with folder_slug
+            folder_name = Atoms::TaskIdFormatter.folder_name(formatted_id, folder_slug)
+            task_dir = File.join(@root_dir, folder_name)
+            FileUtils.mkdir_p(task_dir)
 
-            # Write spec file with file_slug
-            spec_filename = Atoms::TaskIdFormatter.spec_filename(formatted_id, file_slug)
-            spec_file = File.join(task_dir, spec_filename)
-            content = build_spec_content(frontmatter: frontmatter, title: title)
-            File.write(spec_file, content)
+            begin
+              # Build frontmatter with all fields
+              effective_status = status || @config.dig("task", "default_status") || "pending"
+              frontmatter = Atoms::TaskFrontmatterDefaults.build(
+                id: formatted_id,
+                status: effective_status,
+                priority: priority,
+                tags: tags,
+                dependencies: dependencies,
+                created_at: time,
+                estimate: estimate,
+                github_issue: github_issue
+              )
 
-            # Load and return the created task
-            loader = TaskLoader.new
-            loader.load(task_dir, id: formatted_id)
-          rescue StandardError
-            FileUtils.rm_rf(task_dir) if Dir.exist?(task_dir)
-            raise
+              # Write spec file with file_slug
+              spec_filename = Atoms::TaskIdFormatter.spec_filename(formatted_id, file_slug)
+              spec_file = File.join(task_dir, spec_filename)
+              content = build_spec_content(frontmatter: frontmatter, title: title)
+              File.write(spec_file, content)
+
+              # Load and return the created task
+              loader = TaskLoader.new
+              loader.load(task_dir, id: formatted_id)
+            rescue StandardError
+              FileUtils.rm_rf(task_dir) if Dir.exist?(task_dir)
+              raise
+            end
           end
         end
 
         private
 
         def task_id_exists?(formatted_id)
-          escaped = Regexp.escape(formatted_id)
-          Dir.glob(File.join(@root_dir, "**", "*")).any? do |path|
-            File.directory?(path) && File.basename(path).match?(/\A#{escaped}-/)
+          Dir.glob(File.join(@root_dir, "**", "#{formatted_id}-*")).any? do |path|
+            File.directory?(path)
           end
+        end
+
+        def with_id_reservation(formatted_id)
+          reservation_path = File.join(@root_dir, ".ace-task-id-lock-#{formatted_id}")
+          acquired = false
+          Dir.mkdir(reservation_path)
+          acquired = true
+          yield
+        rescue Errno::EEXIST
+          raise IdCollisionError, "Task ID collision detected for #{formatted_id}"
+        ensure
+          FileUtils.rm_rf(reservation_path) if acquired && reservation_path && Dir.exist?(reservation_path)
         end
 
         def generate_folder_slug(title)

--- a/ace-task/lib/ace/task/molecules/task_creator.rb
+++ b/ace-task/lib/ace/task/molecules/task_creator.rb
@@ -13,6 +13,8 @@ module Ace
       # Generates folder structure and spec file with full frontmatter.
       # Optionally uses LLM for slug generation with deterministic fallback.
       class TaskCreator
+        class IdCollisionError < StandardError; end
+
         # @param root_dir [String] Root directory for tasks
         # @param config [Hash] Configuration hash
         def initialize(root_dir:, config: {})
@@ -45,6 +47,7 @@ module Ace
           # Generate task ID
           item_id = Atoms::TaskIdFormatter.generate(time)
           formatted_id = item_id.formatted_id
+          raise IdCollisionError, "Task ID collision detected for #{formatted_id}" if task_id_exists?(formatted_id)
 
           # Generate slugs
           slugs = if use_llm_slug
@@ -60,31 +63,43 @@ module Ace
           task_dir = File.join(@root_dir, folder_name)
           FileUtils.mkdir_p(task_dir)
 
-          # Build frontmatter with all fields
-          effective_status = status || @config.dig("task", "default_status") || "pending"
-          frontmatter = Atoms::TaskFrontmatterDefaults.build(
-            id: formatted_id,
-            status: effective_status,
-            priority: priority,
-            tags: tags,
-            dependencies: dependencies,
-            created_at: time,
-            estimate: estimate,
-            github_issue: github_issue
-          )
+          begin
+            # Build frontmatter with all fields
+            effective_status = status || @config.dig("task", "default_status") || "pending"
+            frontmatter = Atoms::TaskFrontmatterDefaults.build(
+              id: formatted_id,
+              status: effective_status,
+              priority: priority,
+              tags: tags,
+              dependencies: dependencies,
+              created_at: time,
+              estimate: estimate,
+              github_issue: github_issue
+            )
 
-          # Write spec file with file_slug
-          spec_filename = Atoms::TaskIdFormatter.spec_filename(formatted_id, file_slug)
-          spec_file = File.join(task_dir, spec_filename)
-          content = build_spec_content(frontmatter: frontmatter, title: title)
-          File.write(spec_file, content)
+            # Write spec file with file_slug
+            spec_filename = Atoms::TaskIdFormatter.spec_filename(formatted_id, file_slug)
+            spec_file = File.join(task_dir, spec_filename)
+            content = build_spec_content(frontmatter: frontmatter, title: title)
+            File.write(spec_file, content)
 
-          # Load and return the created task
-          loader = TaskLoader.new
-          loader.load(task_dir, id: formatted_id)
+            # Load and return the created task
+            loader = TaskLoader.new
+            loader.load(task_dir, id: formatted_id)
+          rescue StandardError
+            FileUtils.rm_rf(task_dir) if Dir.exist?(task_dir)
+            raise
+          end
         end
 
         private
+
+        def task_id_exists?(formatted_id)
+          escaped = Regexp.escape(formatted_id)
+          Dir.glob(File.join(@root_dir, "**", "*")).any? do |path|
+            File.directory?(path) && File.basename(path).match?(/\A#{escaped}-/)
+          end
+        end
 
         def generate_folder_slug(title)
           sanitized = Ace::Support::Items::Atoms::SlugSanitizer.sanitize(title)

--- a/ace-task/lib/ace/task/organisms/task_doctor.rb
+++ b/ace-task/lib/ace/task/organisms/task_doctor.rb
@@ -3,6 +3,7 @@
 require_relative "../molecules/task_scanner"
 require_relative "../molecules/task_frontmatter_validator"
 require_relative "../molecules/task_structure_validator"
+require_relative "../molecules/task_doctor_fixer"
 require_relative "../atoms/task_validation_rules"
 
 module Ace
@@ -108,12 +109,19 @@ module Ace
           scanner = Molecules::TaskScanner.new(@root_path)
           return unless scanner.root_exists?
 
-          scan_results = scanner.scan
+          scan_results = frontmatter_scan_results(scanner)
           @stats[:tasks_scanned] = scan_results.size
+          id_locations = Hash.new { |hash, key| hash[key] = [] }
 
           scan_results.each do |scan_result|
             spec_file = scan_result.file_path
             next unless spec_file && File.exist?(spec_file)
+
+            content = File.read(spec_file)
+            frontmatter, _body = Ace::Support::Items::Atoms::FrontmatterParser.parse(content)
+            if frontmatter.is_a?(Hash) && frontmatter["id"] && !frontmatter["id"].to_s.strip.empty?
+              id_locations[frontmatter["id"]] << spec_file
+            end
 
             issues = Molecules::TaskFrontmatterValidator.validate(
               spec_file,
@@ -127,6 +135,8 @@ module Ace
               add_issue(issue[:type], issue[:message], issue[:location])
             end
           end
+
+          add_duplicate_id_issues(id_locations)
         end
 
         def run_scope_check
@@ -173,6 +183,26 @@ module Ace
             end
           end
           count
+        end
+
+        def frontmatter_scan_results(scanner)
+          top_level_results = scanner.scan
+          subtask_results = top_level_results.flat_map { |scan_result|
+            scanner.scan_subtasks(scan_result.dir_path, parent_id: scan_result.id)
+          }
+          top_level_results + subtask_results
+        end
+
+        def add_duplicate_id_issues(id_locations)
+          id_locations.each do |id, locations|
+            next unless locations.size > 1
+
+            add_issue(
+              :error,
+              "Duplicate task ID '#{id}' found in: #{locations.sort.join(', ')}",
+              locations.first
+            )
+          end
         end
 
         def add_issue(type, message, location = nil)

--- a/ace-task/lib/ace/task/organisms/task_manager.rb
+++ b/ace-task/lib/ace/task/organisms/task_manager.rb
@@ -16,6 +16,9 @@ module Ace
       # Orchestrates all task CRUD operations.
       # Entry point for task management with config-driven root directory.
       class TaskManager
+        CREATE_RETRY_LIMIT = 3
+        class CreateRetriesExhaustedError < StandardError; end
+
         attr_reader :last_list_total, :last_folder_counts
 
         # @param root_dir [String, nil] Override root directory for tasks
@@ -49,18 +52,28 @@ module Ace
           ensure_root_dir
           ensure_github_issue_linkable!(github_issue)
           creator = Molecules::TaskCreator.new(root_dir: @root_dir, config: @config)
-          created_task = creator.create(
-            title,
-            status: status,
-            priority: priority,
-            tags: tags,
-            dependencies: dependencies,
-            use_llm_slug: use_llm_slug,
-            estimate: estimate,
-            github_issue: github_issue
-          )
-          sync_linked_issues_for(created_task, reason: "create")
-          created_task
+          attempts = 0
+
+          begin
+            attempts += 1
+            created_task = creator.create(
+              title,
+              status: status,
+              priority: priority,
+              tags: tags,
+              dependencies: dependencies,
+              use_llm_slug: use_llm_slug,
+              time: Time.now.utc + ((attempts - 1) * 2),
+              estimate: estimate,
+              github_issue: github_issue
+            )
+            sync_linked_issues_for(created_task, reason: "create")
+            created_task
+          rescue Molecules::TaskCreator::IdCollisionError
+            retry if attempts < CREATE_RETRY_LIMIT
+            raise CreateRetriesExhaustedError,
+              "Failed to create task: unable to generate a unique ID after #{CREATE_RETRY_LIMIT} attempts"
+          end
         end
 
         # Show (load) a single task by reference, including subtasks.

--- a/ace-task/lib/ace/task/version.rb
+++ b/ace-task/lib/ace/task/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Task
-    VERSION = '0.34.2'
+    VERSION = '0.34.3'
   end
 end

--- a/ace-task/lib/ace/task/version.rb
+++ b/ace-task/lib/ace/task/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Task
-    VERSION = '0.35.0'
+    VERSION = '0.35.1'
   end
 end

--- a/ace-task/lib/ace/task/version.rb
+++ b/ace-task/lib/ace/task/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Task
-    VERSION = '0.34.3'
+    VERSION = '0.35.0'
   end
 end

--- a/ace-task/lib/ace/task/version.rb
+++ b/ace-task/lib/ace/task/version.rb
@@ -2,6 +2,6 @@
 
 module Ace
   module Task
-    VERSION = '0.34.1'
+    VERSION = '0.34.2'
   end
 end

--- a/ace-task/test/fast/atoms/task_validation_rules_test.rb
+++ b/ace-task/test/fast/atoms/task_validation_rules_test.rb
@@ -74,6 +74,11 @@ class TaskValidationRulesTest < AceTaskTestCase
     assert Rules.valid_id?("8pp.t.q7w")
   end
 
+  def test_valid_id_accepts_formatted_subtask_id
+    assert Rules.valid_id?("8pp.t.q7w.0")
+    assert Rules.valid_id?("8pp.t.q7w.a")
+  end
+
   def test_valid_id_rejects_raw_b36ts
     refute Rules.valid_id?("8ppq7w")
   end

--- a/ace-task/test/fast/commands/create_test.rb
+++ b/ace-task/test/fast/commands/create_test.rb
@@ -224,4 +224,62 @@ class CreateCommandTest < AceTaskTestCase
       assert_match(/Info: GitHub sync warning for task 8pp\.t\.abc: gh unavailable/, output)
     end
   end
+
+  def test_create_retries_when_generated_id_collides
+    tasks_dir = File.join(@tmpdir, ".ace-tasks")
+    colliding_id = "8pp.t.q7w"
+    existing_dir = File.join(tasks_dir, "#{colliding_id}-existing-task")
+    FileUtils.mkdir_p(existing_dir)
+    File.write(
+      File.join(existing_dir, "#{colliding_id}-existing-task.s.md"),
+      "---\nid: #{colliding_id}\nstatus: pending\n---\n\n# Existing task\n"
+    )
+
+    ids = [
+      Struct.new(:formatted_id).new(colliding_id),
+      Struct.new(:formatted_id).new("8pp.t.q7x")
+    ]
+    idx = 0
+    generator = lambda do |_time = nil|
+      value = ids[[idx, ids.length - 1].min]
+      idx += 1
+      value
+    end
+
+    output = nil
+    Ace::Task::Atoms::TaskIdFormatter.stub(:generate, generator) do
+      output = capture_io do
+        Ace::Task::TaskCLI.start(["create", "Retry create task"])
+      end.first
+    end
+
+    assert_match(/Created task 8pp\.t\.q7x/, output)
+    created_dirs = Dir.glob(File.join(tasks_dir, "8pp.t.q7x-*"))
+    assert_equal 1, created_dirs.length
+  end
+
+  def test_create_fails_clearly_when_collision_retries_exhausted
+    tasks_dir = File.join(@tmpdir, ".ace-tasks")
+    colliding_id = "8pp.t.q7w"
+    existing_dir = File.join(tasks_dir, "#{colliding_id}-existing-task")
+    FileUtils.mkdir_p(existing_dir)
+    File.write(
+      File.join(existing_dir, "#{colliding_id}-existing-task.s.md"),
+      "---\nid: #{colliding_id}\nstatus: pending\n---\n\n# Existing task\n"
+    )
+
+    item_id = Struct.new(:formatted_id).new(colliding_id)
+    err = nil
+    Ace::Task::Atoms::TaskIdFormatter.stub(:generate, item_id) do
+      err = assert_raises(Ace::Support::Cli::Error) do
+        capture_io do
+          Ace::Task::TaskCLI.start(["create", "Will fail after retries"])
+        end
+      end
+    end
+
+    assert_match(/unable to generate a unique ID after 3 attempts/i, err.message)
+    colliding_dirs = Dir.glob(File.join(tasks_dir, "#{colliding_id}-*"))
+    assert_equal 1, colliding_dirs.length, "Expected no extra artifacts for exhausted retries"
+  end
 end

--- a/ace-task/test/fast/commands/doctor_test.rb
+++ b/ace-task/test/fast/commands/doctor_test.rb
@@ -156,6 +156,21 @@ class TaskDoctorCliTest < AceTaskTestCase
     end
   end
 
+  def test_doctor_check_frontmatter_fails_on_duplicate_ids
+    with_tasks_dir do |root|
+      create_task_fixture(root, id: "8pp.t.q7w", slug: "task-one", status: "pending", tags: ["test"])
+      create_task_fixture(root, id: "8pp.t.q7w", slug: "task-two", status: "pending", tags: ["test"])
+
+      with_cli_root(root) do
+        result = run_cli(["doctor", "--check", "frontmatter"])
+        assert_equal 1, result[:exit_code]
+        assert_includes result[:stdout], "Duplicate task ID '8pp.t.q7w'"
+        assert_includes result[:stdout], "task-one"
+        assert_includes result[:stdout], "task-two"
+      end
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # --errors-only
   # ---------------------------------------------------------------------------
@@ -221,6 +236,19 @@ class TaskDoctorCliTest < AceTaskTestCase
       result = run_cli(["doctor"])
       assert_equal 1, result[:exit_code]
       assert_includes result[:stderr], "not found"
+    end
+  end
+
+  def test_doctor_fails_on_duplicate_ids
+    with_tasks_dir do |root|
+      create_task_fixture(root, id: "8pp.t.q7w", slug: "task-one", status: "pending", tags: ["test"])
+      create_task_fixture(root, id: "8pp.t.q7w", slug: "task-two", status: "pending", tags: ["test"])
+
+      with_cli_root(root) do
+        result = run_cli(["doctor"])
+        assert_equal 1, result[:exit_code]
+        assert_includes result[:stdout], "Duplicate task ID '8pp.t.q7w'"
+      end
     end
   end
 end

--- a/ace-task/test/fast/molecules/task_creator_test.rb
+++ b/ace-task/test/fast/molecules/task_creator_test.rb
@@ -125,4 +125,40 @@ class TaskCreatorTest < AceTaskTestCase
     assert_includes content, "tags: [api]"
     assert_includes content, "created_at:"
   end
+
+  def test_raises_id_collision_when_generated_task_id_already_exists
+    creator = Ace::Task::Molecules::TaskCreator.new(root_dir: @tmpdir)
+    colliding_id = "8pp.t.q7w"
+    existing_dir = File.join(@tmpdir, "#{colliding_id}-existing-task")
+    FileUtils.mkdir_p(existing_dir)
+    File.write(
+      File.join(existing_dir, "#{colliding_id}-existing-task.s.md"),
+      "---\nid: #{colliding_id}\nstatus: pending\n---\n\n# Existing\n"
+    )
+
+    item_id = Struct.new(:formatted_id).new(colliding_id)
+    Ace::Task::Atoms::TaskIdFormatter.stub(:generate, item_id) do
+      assert_raises(Ace::Task::Molecules::TaskCreator::IdCollisionError) do
+        creator.create("New task with colliding ID")
+      end
+    end
+  end
+
+  def test_cleans_up_partial_artifacts_when_create_fails_after_write
+    creator = Ace::Task::Molecules::TaskCreator.new(root_dir: @tmpdir)
+    item_id = Struct.new(:formatted_id).new("8pp.t.q7x")
+    failing_loader = Object.new
+    failing_loader.define_singleton_method(:load) do |_path, id:|
+      raise "simulated loader failure for #{id}"
+    end
+
+    Ace::Task::Atoms::TaskIdFormatter.stub(:generate, item_id) do
+      Ace::Task::Molecules::TaskLoader.stub(:new, failing_loader) do
+        assert_raises(RuntimeError) { creator.create("Task with failing load") }
+      end
+    end
+
+    created_paths = Dir.glob(File.join(@tmpdir, "8pp.t.q7x-*"))
+    assert_empty created_paths, "Expected partial task artifacts to be cleaned up"
+  end
 end

--- a/ace-task/test/fast/molecules/task_creator_test.rb
+++ b/ace-task/test/fast/molecules/task_creator_test.rb
@@ -144,6 +144,24 @@ class TaskCreatorTest < AceTaskTestCase
     end
   end
 
+  def test_raises_id_collision_when_id_reservation_is_already_held
+    creator = Ace::Task::Molecules::TaskCreator.new(root_dir: @tmpdir)
+    colliding_id = "8pp.t.q7z"
+    reservation = File.join(@tmpdir, ".ace-task-id-lock-#{colliding_id}")
+    Dir.mkdir(reservation)
+
+    item_id = Struct.new(:formatted_id).new(colliding_id)
+    Ace::Task::Atoms::TaskIdFormatter.stub(:generate, item_id) do
+      assert_raises(Ace::Task::Molecules::TaskCreator::IdCollisionError) do
+        creator.create("New task while lock is held")
+      end
+    end
+
+    assert Dir.exist?(reservation), "Expected existing reservation lock to remain untouched"
+  ensure
+    FileUtils.rm_rf(reservation) if reservation && Dir.exist?(reservation)
+  end
+
   def test_cleans_up_partial_artifacts_when_create_fails_after_write
     creator = Ace::Task::Molecules::TaskCreator.new(root_dir: @tmpdir)
     item_id = Struct.new(:formatted_id).new("8pp.t.q7x")

--- a/ace-task/test/fast/organisms/task_doctor_test.rb
+++ b/ace-task/test/fast/organisms/task_doctor_test.rb
@@ -58,6 +58,22 @@ class TaskDoctorTest < AceTaskTestCase
     end
   end
 
+  def test_specific_check_frontmatter_detects_duplicate_task_ids
+    with_tasks_dir do |root|
+      create_task_fixture(root, id: "8pp.t.q7w", slug: "task-one")
+      create_task_fixture(root, id: "8pp.t.q7w", slug: "task-two")
+
+      doctor = Doctor.new(root, check: "frontmatter")
+      results = doctor.run_diagnosis
+
+      refute results[:valid]
+      duplicate_issue = results[:issues].find { |issue| issue[:message].include?("Duplicate task ID '8pp.t.q7w'") }
+      refute_nil duplicate_issue
+      assert_includes duplicate_issue[:message], "task-one"
+      assert_includes duplicate_issue[:message], "task-two"
+    end
+  end
+
   def test_specific_check_scope
     with_tasks_dir do |root|
       create_task_fixture(root, id: "8pp.t.q7w", slug: "test-task")
@@ -155,6 +171,57 @@ class TaskDoctorTest < AceTaskTestCase
       doctor = Doctor.new(root)
       results = doctor.run_diagnosis
       assert results[:issues].any? { |i| i[:message].include?("not in _archive") }
+    end
+  end
+
+  def test_detects_duplicate_top_level_task_ids
+    with_tasks_dir do |root|
+      create_task_fixture(root, id: "8pp.t.q7w", slug: "task-one")
+      create_task_fixture(root, id: "8pp.t.q7w", slug: "task-two")
+
+      doctor = Doctor.new(root)
+      results = doctor.run_diagnosis
+
+      refute results[:valid]
+      duplicate_issue = results[:issues].find { |issue| issue[:message].include?("Duplicate task ID '8pp.t.q7w'") }
+      refute_nil duplicate_issue
+      assert_includes duplicate_issue[:message], "task-one"
+      assert_includes duplicate_issue[:message], "task-two"
+    end
+  end
+
+  def test_detects_duplicate_subtask_ids
+    with_tasks_dir do |root|
+      parent_dir = create_task_fixture(root, id: "8pp.t.q7w", slug: "parent-task")
+      subtask_a_dir = File.join(parent_dir, "0-first-subtask")
+      subtask_b_dir = File.join(parent_dir, "1-second-subtask")
+      FileUtils.mkdir_p(subtask_a_dir)
+      FileUtils.mkdir_p(subtask_b_dir)
+
+      File.write(File.join(subtask_a_dir, "8pp.t.q7w.0-first-subtask.s.md"), <<~CONTENT)
+        ---
+        id: 8pp.t.q7w.0
+        status: pending
+        parent: 8pp.t.q7w
+        ---
+      CONTENT
+
+      File.write(File.join(subtask_b_dir, "8pp.t.q7w.1-second-subtask.s.md"), <<~CONTENT)
+        ---
+        id: 8pp.t.q7w.0
+        status: pending
+        parent: 8pp.t.q7w
+        ---
+      CONTENT
+
+      doctor = Doctor.new(root)
+      results = doctor.run_diagnosis
+
+      refute results[:valid]
+      duplicate_issue = results[:issues].find { |issue| issue[:message].include?("Duplicate task ID '8pp.t.q7w.0'") }
+      refute_nil duplicate_issue
+      assert_includes duplicate_issue[:message], "0-first-subtask"
+      assert_includes duplicate_issue[:message], "1-second-subtask"
     end
   end
 end


### PR DESCRIPTION
## 📋 Summary

Creating tasks and ideas is safer now when generated IDs collide, and doctor checks now stop on duplicate persisted IDs instead of silently letting corrupted state through.
Before this batch, duplicate IDs could survive health checks, create flows could treat same-ID edge cases as success, and collision retries were not consistently enforced across `ace-task` and `ace-idea`.

## ✏️ Changes

- Add **duplicate-ID doctor enforcement**: `ace-task` and `ace-idea` now fail doctor health checks when persisted IDs collide, including frontmatter-only doctor runs and task subtask collisions (`629a09064`, `993f3232d`, `7cdd5c660`, `d8f066462`).
- Add **create-time collision retries**: `ace-task create` and `ace-idea create` now retry bounded ID generation, fail cleanly when retries are exhausted, and reject the old same-ID/different-slug success path for ideas (`b9663b4e5`, `33aac8430`, `a52017c0c`, `b1a2b439c`).
- Update **public contract docs and release surfaces**: package usage docs, package changelogs, root release notes, and final minor versions now reflect the new lifecycle guarantees (`3ec94ef1e`, `4224ac4c3`, `0e7d9b586`, `dfab797e7`, `a8b17b77c`).

## 📁 File Changes

```text
 +655,   -50   29 files   total

 +285,   -33   12 files      ace-idea/
  +56,    -4    5 files   🧱 lib/
   +5,    -1                 ace/idea/cli/commands/create.rb
  +16,    -1                 ace/idea/molecules/idea_creator.rb
  +21,    -0                 ace/idea/organisms/idea_doctor.rb
  +13,    -1                 .../idea_manager.rb
   +1,    -1                 ace/idea/version.rb
 +191,   -27    5 files   🧪 test/
  +56,    -0                 fast/commands/idea_cli_test.rb
  +28,    -0                 .../idea_doctor_cli_test.rb
  +38,    -0                 fast/molecules/idea_creator_test.rb
  +32,    -0                 fast/organisms/idea_doctor_test.rb
  +37,   -27                 feat/idea_lifecycle_feature_test.rb
  +38,    -2    2 files      
  +28,    -0                 CHANGELOG.md
  +10,    -2                 docs/usage.md

 +291,    -4   11 files      ace-task/
  +65,    -3    5 files   🧱 lib/
   +5,    -1                 ace/task/cli/commands/create.rb
  +15,    -0                 ace/task/molecules/task_creator.rb
  +31,    -1                 ace/task/organisms/task_doctor.rb
  +13,    -0                 .../task_manager.rb
   +1,    -1                 ace/task/version.rb
 +189,    -0    4 files   🧪 test/
  +58,    -0                 fast/commands/create_test.rb
  +28,    -0                 .../doctor_test.rb
  +36,    -0                 fast/molecules/task_creator_test.rb
  +67,    -0                 fast/organisms/task_doctor_test.rb
  +37,    -1    2 files      
  +27,    -0                 CHANGELOG.md
  +10,    -1                 docs/usage.md

  +24,   -13    3 files      .ace-tasks/
   +6,    -6                 8r6.t.hl3-enforce-unique-ids-across-task/0-flag-collisions-in-doctor-health/8r6.t.hl3.0-flag-collisions-in-doctor-health-checks-for.s.md
   +7,    -7                 8r6.t.hl3-enforce-unique-ids-across-task/1-retry-create-when-generated-identifiers/8r6.t.hl3.1-retry-create-when-generated-identifiers-collide.s.md
  +11,    -0                 8rc.t.k2l-fix-ace-task-plan-content/8rc.t.k2l-fix-ace-task-plan-content-stall-during.s.md

  +53,    -0    2 files      .ace-retros/
  +28,    -0                 8rcjp4-assignment-8rcjeb-task-8r6thl30-closeout/8rcjp4-assignment-8rcjeb-task-8r6thl30-closeout.retro.md
  +25,    -0                 8rckbk-assignment-8rcjeb-task-8r6thl31-retrospective/8rckbk-assignment-8rcjeb-task-8r6thl31-retrospective.retro.md

   +2,    -0    1 files      ./
   +2,    -0                 CHANGELOG.md
```

## 🧪 Test Evidence

- **TaskDoctorTest / DoctorTest** — validates duplicate persisted task IDs now fail doctor health checks, including frontmatter-only checks and subtask collisions.
- **IdeaDoctorTest / IdeaDoctorCliTest** — validates duplicate persisted idea IDs now fail doctor health checks and report path-specific failures.
- **TaskCreatorTest / CreateTest** — validates bounded retry behavior and clean failure semantics for task ID collisions.
- **IdeaCreatorTest / IdeaCliTest / idea_lifecycle_feature_test** — validates bounded retry behavior for ideas and rejects same-ID/different-slug creation as a successful path.
- **Package verification** — `ace-task all --profile 6` passed with 371 tests / 0 failures; `ace-idea all --profile 6` passed with 267 tests / 0 failures.
- **Monorepo verification** — `ace-test-suite --target all` passed with 43 packages, 8810 tests, 0 failures, 44 skips.
- **Release proof** — `ace-test-e2e ace-monorepo-e2e TS-MONO-001` passed 4/4 cases with `SAFE` classification.

## 📦 Releases

- **ace-task v0.35.0** — ships duplicate persisted-ID doctor failures, frontmatter duplicate enforcement, and bounded create-time collision retries with no partial artifact leakage.
- **ace-idea v0.20.0** — ships duplicate persisted-ID doctor failures, bounded create-time collision retries, and rejection of same-ID/different-slug idea creation.

## 🎮 Demo

### Run

```bash
ace-task doctor --check frontmatter
ace-idea doctor --check frontmatter
ace-task create "Collision-safe task"
ace-idea create "Collision-safe idea"
```

### Expected Output

- Doctor exits non-zero when duplicate persisted IDs are present instead of silently reporting healthy state.
- Create either succeeds with a newly persisted unique ID or fails cleanly after bounded retries without leaving a partial task or idea artifact behind.

### Artifacts

- Package docs: `ace-task/docs/usage.md`, `ace-idea/docs/usage.md`
- Release proof: `.ace-local/test-e2e/8rckeji-monorepo-e2e-ts001-reports/report.md`
