### PR TITLE
8re.t.mh0: continue forked assignments without manual nudges

### DIFF
--- a/.ace-tasks/8re.t.mh0-harden-assignment-drive-continuation-and/0-spike-deterministic-ace-assign-watch/8re.t.mh0.0-spike-deterministic-ace-assign-watch-continuation.s.md
+++ b/.ace-tasks/8re.t.mh0-harden-assignment-drive-continuation-and/0-spike-deterministic-ace-assign-watch/8re.t.mh0.0-spike-deterministic-ace-assign-watch-continuation.s.md
@@ -1,0 +1,125 @@
+---
+id: 8re.t.mh0.0
+status: draft
+priority: medium
+created_at: "2026-04-15 14:59:00"
+estimate: TBD
+dependencies: []
+tags: []
+parent: 8re.t.mh0
+bundle:
+  presets: [project]
+  files: [ace-assign/lib/ace/assign/cli/commands/watch.rb, ace-assign/lib/ace/assign/cli.rb, ace-assign/handbook/workflow-instructions/assign/drive.wf.md, ace-assign/test/fast/commands/watch_command_test.rb, ace-assign/test/fast/organisms/assign_drive_contract_test.rb]
+  commands: [ace-task show 8re.t.mh0 --content, ace-task show 8re.t.mh0.0 --content, ace-assign watch --help]
+needs_review: false
+---
+
+# Spike deterministic ace-assign watch continuation contract
+
+## Objective
+
+Validate the end-state contract for deterministic fork continuation so one watcher invocation can wait for active forked work, recover from interruption, and launch the next eligible fork subtree until a real stop boundary is reached.
+
+## Behavioral Specification
+
+### User Experience
+
+- An operator or agent can invoke `ace-assign watch` once and trust it to keep moving through fork-enabled child subtrees.
+- If the original fork session disappears but assignment state still shows in-flight work, the watcher recovers instead of requiring manual restart choreography.
+- The watcher reports clearly when it stops because only inline/manual work remains instead of silently idling.
+- The spike produces a stable concept inventory for continuation semantics before any larger decomposition is attempted.
+
+### Expected Behavior
+
+1. The spike validates one coherent continuation path from watcher start through active-fork waiting, interruption recovery, and immediate next-child launch.
+2. The spike explicitly keeps `ace-assign status` as the authority for completion and failure.
+3. The spike defines how PID/session metadata is used only to decide whether to wait or recover, not to declare completion.
+4. The spike defines the watcher stop boundary when the next remaining step requires inline/manual execution.
+5. The spike defines failure behavior when the watched subtree or assignment enters a failed state.
+6. The spike updates the parent concept inventory if any candidate concept should be kept, changed, or rejected.
+
+### Interface Contract
+
+- **Watcher invocation**
+  ```bash
+  ace-assign watch --assignment 8rddnp
+  ace-assign watch --assignment 8rddnp --root 010.03
+  ace-assign watch --assignment 8rddnp --poll-interval 300
+  ```
+- **Behavioral contract**
+  - `watch` waits while an active fork session is alive.
+  - `watch` re-enters fork execution from assignment state when session liveness is gone but fork work remains non-terminal.
+  - `watch` launches the next eligible fork subtree immediately after completion of the current child.
+  - `watch` stops when the watched scope is complete, failed, or the next actionable step is non-fork inline/manual work.
+
+### Success Criteria
+
+- [ ] One validated continuation scenario exists for wait, recover, and continue behavior.
+- [ ] The spike leaves no behavioral ambiguity about source of truth, liveness checks, recovery, next-child launch, or stop boundaries.
+- [ ] The spike confirms `watch` is deterministic fork orchestration, not a general-purpose assignment executor.
+- [ ] The parent task can safely rely on the spike outcome when describing watcher behavior.
+
+## Vertical Slice Decomposition (Task/Subtask Model)
+
+- **Slice type**: subtask spike
+- **Slice outcome**: validated continuation/recovery contract for `ace-assign watch`
+- **Advisory size**: small
+- **Context dependencies**: parent draft, watcher command surface, drive workflow contract, fast watcher coverage
+
+## Verification Plan
+
+### Unit / Component Validation
+
+- Review the watcher contract and confirm it distinguishes waiting, recovery, and launch-next behaviors cleanly.
+- Confirm the spike keeps PID/session data as liveness hints only.
+- Confirm the spike treats inline/manual execution as an explicit stop boundary.
+
+### Integration / E2E Validation
+
+- Trace a fork-enabled assignment with successive child roots and confirm the watcher contract supports one-invocation continuation.
+- Trace an interruption scenario and confirm the watcher contract supports re-entry from assignment state.
+
+### Failure / Invalid Path Validation
+
+- Confirm the spike specifies behavior when a watched subtree fails.
+- Confirm the spike specifies behavior when the root scope is not fork-enabled or does not exist.
+- Confirm the spike specifies stop behavior when only inline/manual work remains.
+
+### Verification Commands
+
+- `ace-task show 8re.t.mh0.0 --content`
+- `ace-assign watch --help`
+
+## Scope of Work
+
+- Validate watcher continuation semantics
+- Validate watcher recovery semantics
+- Validate watcher stop and failure boundaries
+- Refine the parent task if the concept inventory changes
+
+## Deliverables
+
+### Behavioral Specifications
+
+- deterministic watcher continuation contract
+- liveness-hint versus status-authority contract
+- inline/manual stop-boundary contract
+
+### Validation Artifacts
+
+- stable concept inventory for watcher behavior
+- parent-task refinements if needed
+
+## Out of Scope
+
+- implementing runtime code in this drafting step
+- designing callback payload schema beyond the handoff needed to parent task `8re.t.mh0.1`
+- turning the watcher into a generic runner for non-fork steps
+
+## References
+
+- parent task `8re.t.mh0`
+- `ace-assign/lib/ace/assign/cli/commands/watch.rb`
+- `ace-assign/lib/ace/assign/cli.rb`
+- `ace-assign/handbook/workflow-instructions/assign/drive.wf.md`
+- `ace-assign/test/fast/commands/watch_command_test.rb`

--- a/.ace-tasks/8re.t.mh0-harden-assignment-drive-continuation-and/1-specify-tmux-callback-notification-contract/8re.t.mh0.1-specify-tmux-callback-notification-contract-for.s.md
+++ b/.ace-tasks/8re.t.mh0-harden-assignment-drive-continuation-and/1-specify-tmux-callback-notification-contract/8re.t.mh0.1-specify-tmux-callback-notification-contract-for.s.md
@@ -1,0 +1,136 @@
+---
+id: 8re.t.mh0.1
+status: draft
+priority: medium
+created_at: "2026-04-15 14:59:00"
+estimate: TBD
+dependencies: []
+tags: []
+parent: 8re.t.mh0
+bundle:
+  presets: [project]
+  files: [docs/decisions/ADR-034-assignment-watch-and-callback-contract.md, ace-assign/lib/ace/assign/cli/commands/watch.rb, ace-assign/handbook/workflow-instructions/assign/drive.wf.md]
+  commands: [ace-task show 8re.t.mh0.1 --content, ace-task show 8re.t.mh0 --content]
+needs_review: false
+---
+
+# Specify tmux callback notification contract for assignment watch
+
+## Objective
+
+Define a notification-only callback contract that lets `ace-assign watch` wake parent operators or agents through tmux targets without changing status authority or mutating assignment state.
+
+## Behavioral Specification
+
+### User Experience
+
+- A parent operator or agent can reserve a tmux callback target and get a wake-up signal when meaningful watcher events occur.
+- Callback delivery never becomes the authoritative record of assignment progress; it is only a prompt to re-check status.
+- If callback delivery fails, assignment watching still behaves correctly and the underlying assignment state remains intact.
+
+### Expected Behavior
+
+1. The callback surface is expressed as an optional watcher argument using the shape `tmux:<target>`.
+2. The target accepts standard tmux targets, including pane identifiers such as `%42`.
+3. The watcher may emit callbacks for subtree completion, subtree failure, assignment blocked, and assignment completed events.
+4. Callback payloads are single-line, machine-readable wake-up messages rather than full status replacements.
+5. Callback consumers must re-run `ace-assign status` before taking action.
+6. Callback delivery failure is non-fatal and must not corrupt assignment state or watcher progress.
+
+### Interface Contract
+
+- **Reserved interface**
+  ```bash
+  ace-assign watch --assignment 8rddnp --callback tmux:%42
+  ```
+- **Reserved events**
+  - `subtree_completed`
+  - `subtree_failed`
+  - `assignment_blocked`
+  - `assignment_completed`
+- **Payload contract**
+  - Prefix: `ACE_ASSIGN_EVENT `
+  - JSON object keys:
+    - `assignment_id`
+    - `scope`
+    - `event`
+    - `current_step`
+    - `next_step`
+    - `session_id`
+    - `report_path_or_dir`
+    - `resume_command`
+    - `timestamp`
+- **Behavioral rules**
+  - Callback delivery is best-effort.
+  - Status remains the source of truth.
+  - Callback failure does not fail the assignment.
+
+### Success Criteria
+
+- [ ] The callback contract has one clear interface shape for tmux targets.
+- [ ] Reserved events and payload fields are explicit enough for future implementation.
+- [ ] The draft leaves no ambiguity that callbacks are wake-up notifications only.
+- [ ] The draft defines non-fatal behavior for callback delivery failures.
+
+## Vertical Slice Decomposition (Task/Subtask Model)
+
+- **Slice type**: subtask design slice
+- **Slice outcome**: stable notification contract layered on `ace-assign watch`
+- **Advisory size**: small
+- **Context dependencies**: watcher contract, ADR for continuation behavior, tmux target semantics
+
+## Verification Plan
+
+### Unit / Component Validation
+
+- Confirm the callback surface is expressed entirely as a watcher-facing interface contract.
+- Confirm the payload fields are enough to let a parent re-check state and decide whether to resume.
+- Confirm the design does not imply callback-led state transitions.
+
+### Integration / E2E Validation
+
+- Walk through a parent-wake-up scenario where a child subtree completes and the parent receives a tmux callback, then re-checks `ace-assign status`.
+- Walk through an assignment-completed scenario and confirm the callback payload carries enough context for a parent closeout step.
+
+### Failure / Invalid Path Validation
+
+- Confirm the design specifies non-fatal behavior for unreachable tmux targets.
+- Confirm the design specifies that malformed or dropped callback deliveries do not alter assignment state.
+- Confirm the design requires consumers to re-check status before acting.
+
+### Verification Commands
+
+- `ace-task show 8re.t.mh0.1 --content`
+- `ace-task show 8re.t.mh0 --content`
+
+## Scope of Work
+
+- Define tmux callback address shape
+- Define reserved events and payload fields
+- Define notification-only semantics and failure handling
+
+## Deliverables
+
+### Behavioral Specifications
+
+- reserved `--callback tmux:<target>` interface contract
+- watcher event vocabulary
+- notification-only callback rules
+
+### Validation Artifacts
+
+- payload field inventory
+- consumer-behavior expectations for re-checking status
+
+## Out of Scope
+
+- implementing callback delivery in this drafting step
+- designing non-tmux callback transports
+- redefining watcher continuation semantics already covered by `8re.t.mh0.0`
+
+## References
+
+- parent task `8re.t.mh0`
+- `docs/decisions/ADR-034-assignment-watch-and-callback-contract.md`
+- `ace-assign/lib/ace/assign/cli/commands/watch.rb`
+- `ace-assign/handbook/workflow-instructions/assign/drive.wf.md`

--- a/.ace-tasks/8re.t.mh0-harden-assignment-drive-continuation-and/8re.t.mh0-harden-assignment-drive-continuation-and-callback.s.md
+++ b/.ace-tasks/8re.t.mh0-harden-assignment-drive-continuation-and/8re.t.mh0-harden-assignment-drive-continuation-and-callback.s.md
@@ -1,0 +1,153 @@
+---
+id: 8re.t.mh0
+status: draft
+priority: medium
+created_at: "2026-04-15 14:58:55"
+estimate: TBD
+dependencies: []
+tags: []
+bundle:
+  presets: [project]
+  files: [ace-assign/lib/ace/assign/cli/commands/watch.rb, ace-assign/lib/ace/assign/cli.rb, ace-assign/handbook/workflow-instructions/assign/drive.wf.md, ace-assign/handbook/skills/as-assign-drive/SKILL.md, docs/decisions/ADR-034-assignment-watch-and-callback-contract.md]
+  commands: [ace-task show 8re.t.mh0 --content, ace-task show 8re.t.mh0.0 --content, ace-task show 8re.t.mh0.1 --content, ace-assign status]
+needs_review: false
+---
+
+# Harden assignment drive continuation and callback handoff
+
+## Objective
+
+Define a durable assignment-drive continuation contract so forked subtrees run one after another without user nudges, and reserve a callback handoff contract that can wake parent operators without replacing assignment status as the source of truth.
+
+## Behavioral Specification
+
+### User Experience
+
+- An operator starts `/as-assign-drive` for a fork-heavy assignment and does not need to keep typing `continue` after every completed child subtree.
+- If a fork subtree is already running when the operator or agent re-enters, the system waits for it, recovers from assignment state if the old session disappeared, and keeps moving.
+- When one fork subtree finishes cleanly, the next eligible fork subtree starts immediately if deterministic queue state allows it.
+- The drive loop stops only at a real end boundary: assignment complete, subtree complete, failed/blocked state, or the next remaining step requires inline/manual agent execution.
+- Future parent notification hooks can wake an operator or parent agent when meaningful events occur, but those hooks do not become the source of truth.
+
+### Expected Behavior
+
+1. `ace-assign watch` provides deterministic fork waiting, interruption recovery, and next-child continuation for fork-enabled assignment work.
+2. `/as-assign-drive` delegates fork wait/resume behavior to `ace-assign watch` instead of relying on prompt wording or conversational sleep loops.
+3. The watcher may use fork PID/session metadata to detect whether a fork session is still alive, but assignment status remains authoritative for completion and failure.
+4. When a watched fork subtree completes, the watcher immediately re-reads status and launches the next eligible fork subtree without handing control back between children.
+5. The watcher stops when the watched scope is complete, the whole assignment is complete, a failed/blocked state is reached, or only inline/manual work remains.
+6. A future callback layer may emit wake-up events for parent coordination, but delivery is best-effort and cannot mutate assignment truth.
+
+### Interface Contract
+
+- **CLI surface**
+  ```bash
+  ace-assign watch --assignment 8rddnp
+  ace-assign watch --assignment 8rddnp --root 010.03
+  ace-assign watch --assignment 8rddnp --poll-interval 300
+  ```
+- **Watcher contract**
+  - `--assignment <id>` identifies the assignment to monitor.
+  - `--root <step>` limits the watcher to a specific fork-enabled subtree root.
+  - `--poll-interval <seconds>` controls how often the watcher re-checks an active fork session while it is still alive.
+  - If a previous fork session is no longer alive but assignment state is still non-terminal, the watcher recovers by re-entering fork execution from assignment state.
+  - If the next actionable step is not fork-enabled and requires inline/manual work, the watcher stops and reports that boundary.
+- **Workflow contract**
+  - `/as-assign-drive` remains the public operator workflow.
+  - `ace-assign watch` becomes the deterministic runtime for fork continuation inside that workflow.
+- **Callback contract**
+  - Callback delivery is notification-only.
+  - Consumers must re-check `ace-assign status` before acting.
+  - Callback failure must not corrupt or fail the assignment.
+
+### Success Criteria
+
+- [ ] Fork-heavy assignments no longer require user nudges between completed child subtrees.
+- [ ] Re-entering a running assignment can wait on an active fork or recover from recorded assignment state after interruption.
+- [ ] The watcher launches the next eligible fork subtree immediately after the previous one completes.
+- [ ] The watcher stops only at completion, blocker/failure, or inline/manual-work boundaries.
+- [ ] Draft usage guidance exists for the new watcher CLI surface and callback reservation.
+
+## Vertical Slice Decomposition (Task/Subtask Model)
+
+- **Slice type**: orchestrator with spike-first decomposition
+- **Slice outcome**: a stable continuation contract for deterministic fork watching plus a separate callback-notification contract
+- **Advisory size**: medium
+- **Context dependencies**: `ace-assign` queue state, fork session metadata, `/as-assign-drive` workflow contract, ADR for callback reservation
+- **Execution shape**
+  - `8re.t.mh0.0`: validate the deterministic `ace-assign watch` continuation contract and the stop/recovery boundaries
+  - `8re.t.mh0.1`: define the notification-only tmux callback contract layered on top of watcher state
+
+## Verification Plan
+
+### Unit / Component Validation
+
+- Validate that the drafted contract keeps `ace-assign status` as the source of truth while allowing PID/session metadata to support wait decisions.
+- Validate that `ace-assign watch` is limited to fork continuation and does not claim to execute arbitrary inline/manual assignment work.
+- Validate that callback delivery remains explicitly advisory and best-effort.
+
+### Integration / E2E Validation
+
+- Walk through a multi-child fork assignment and confirm one invocation can wait, recover, and continue through successive fork subtrees without user prompts.
+- Walk through an interruption case and confirm a new watcher invocation re-enters from assignment state instead of depending on a stale terminal session.
+- Confirm `/as-assign-drive` uses `ace-assign watch` as the deterministic fork path.
+
+### Failure / Invalid Path Validation
+
+- Confirm the draft specifies the stop boundary when the next remaining work is inline/manual rather than fork-enabled.
+- Confirm the draft specifies watcher behavior when a subtree or assignment reaches failed state.
+- Confirm the draft specifies callback-failure behavior as non-fatal.
+
+### Verification Commands
+
+- `ace-task show 8re.t.mh0 --content`
+- `ace-task show 8re.t.mh0.0 --content`
+- `ace-task show 8re.t.mh0.1 --content`
+
+## Scope of Work
+
+- Define the deterministic watcher contract for fork waiting, recovery, and continuation
+- Define how `/as-assign-drive` hands fork continuation off to the watcher
+- Define watcher stop boundaries and source-of-truth semantics
+- Define the reserved callback-notification surface for future parent wake-up behavior
+
+## Deliverables
+
+### Behavioral Specifications
+
+- deterministic `ace-assign watch` contract
+- `/as-assign-drive` delegation contract for fork continuation
+- callback-notification behavioral contract layered on watcher state
+
+### Validation Artifacts
+
+- draft `ux/usage.md` for the watcher CLI surface
+- spike subtask validating continuation/recovery boundaries
+- callback design subtask defining reserved events and payload
+
+## Concept Inventory (Orchestrator Only)
+
+| Concept | Introduced by | Removed by | Status |
+| --- | --- | --- | --- |
+| Deterministic `ace-assign watch` loop | `8re.t.mh0.0` | -- | CANDIDATE |
+| Assignment-state-first recovery | `8re.t.mh0.0` | -- | CANDIDATE |
+| Automatic next-child continuation | `8re.t.mh0.0` | -- | CANDIDATE |
+| Inline/manual stop boundary | `8re.t.mh0.0` | -- | CANDIDATE |
+| Notification-only callback layer | `8re.t.mh0.1` | -- | CANDIDATE |
+| `tmux:<target>` callback address shape | `8re.t.mh0.1` | -- | CANDIDATE |
+
+## Out of Scope
+
+- Implementing new package code during this drafting phase
+- Turning the watcher into a general-purpose executor for all assignment steps
+- Replacing `ace-assign status` with callback signals or tmux state
+- Defining non-tmux callback transports in this task
+
+## References
+
+- `ux/usage.md`
+- `ace-assign/lib/ace/assign/cli/commands/watch.rb`
+- `ace-assign/lib/ace/assign/cli.rb`
+- `ace-assign/handbook/workflow-instructions/assign/drive.wf.md`
+- `ace-assign/handbook/skills/as-assign-drive/SKILL.md`
+- `docs/decisions/ADR-034-assignment-watch-and-callback-contract.md`

--- a/.ace-tasks/8re.t.mh0-harden-assignment-drive-continuation-and/ux/usage.md
+++ b/.ace-tasks/8re.t.mh0-harden-assignment-drive-continuation-and/ux/usage.md
@@ -1,0 +1,59 @@
+# Assignment watch continuation and callback handoff - Draft Usage
+
+## API Surface
+
+- [x] CLI (user-facing commands)
+- [ ] Developer API (modules, classes)
+- [x] Agent API (workflows, protocols, slash commands)
+- [ ] Configuration (config keys, env vars)
+
+## Usage Scenarios
+
+### Scenario 1: Continue a fork-heavy assignment without manual nudges
+
+**Goal**: An operator starts one watcher invocation and lets it wait, recover, and continue across successive forked child subtrees.
+
+```bash
+ace-assign watch --assignment 8rddnp
+```
+
+#### Expected Output
+
+- The watcher announces which assignment or subtree it is watching.
+- If a forked child is already running, the watcher waits and polls until that child reaches a terminal state or needs recovery.
+- When a child subtree completes, the watcher immediately launches the next eligible fork subtree.
+- The watcher stops only when the assignment is complete, failed, blocked, or only inline/manual work remains.
+
+### Scenario 2: Recover deterministic continuation after interruption
+
+**Goal**: A later invocation re-enters from assignment state after the original session disappeared.
+
+```bash
+ace-assign watch --assignment 8rddnp --root 010.03
+```
+
+#### Expected Output
+
+- The watcher resolves the specified fork-enabled subtree root.
+- If assignment state still shows active fork work but the old fork session is no longer alive, the watcher reports recovery and re-enters the subtree from assignment state.
+- Continuation resumes without requiring the user to reconstruct the old terminal session manually.
+
+### Scenario 3: Reserve a tmux wake-up callback
+
+**Goal**: A parent operator or agent receives a lightweight callback when a watcher event occurs.
+
+```bash
+ace-assign watch --assignment 8rddnp --callback tmux:%42
+```
+
+#### Expected Output
+
+- The watcher reserves a notification-only callback target for meaningful events.
+- Emitted messages use the prefix `ACE_ASSIGN_EVENT ` followed by JSON payload data.
+- The receiving side treats the callback as a wake-up signal and re-runs `ace-assign status` before acting.
+- Callback delivery failure does not corrupt or fail the assignment.
+
+## Notes for Implementer
+
+- Full usage documentation should be completed during work-on-task using `wfi://docs/update-usage`.
+- Callback delivery remains a future implementation layer; status must stay authoritative.

--- a/ace-assign/README.md
+++ b/ace-assign/README.md
@@ -49,7 +49,7 @@ Assignment verification uses deterministic commands only:
 
 1. Define steps from a [preset](.ace-defaults/assign/presets/work-on-task.yml) or compose from the [step catalog](.ace-defaults/assign/catalog/steps/) -- steps can nest into substeps and reference workflow instructions for execution details.
 2. Expand the definition into a session with explicit per-step instructions, state tracking (`pending` → `in_progress` → `done`/`failed`), and numbered hierarchy (e.g., `010`, `010.01`, `010.01.01`).
-3. Drive execution with `/as-assign-drive` -- fork long-running steps to isolated agent subprocesses, advance the queue on completion, and retry or inject fix steps on failure.
+3. Drive execution with `/as-assign-drive` -- fork long-running steps to isolated agent subprocesses, use `ace-assign watch` to continue sequential fork work deterministically, and retry or inject fix steps on failure.
 
 ## Use Cases
 
@@ -57,7 +57,7 @@ Assignment verification uses deterministic commands only:
 
 `work-on-task` release steps resolve `wfi://release/publish` from shipped workflow sources by default, and project-level `wfi://` source overrides registered under `.ace/nav/protocols/wfi-sources/` are honored by both `ace-bundle` and `ace-assign`.
 
-**Run with orchestrator and fork agents** - use `/as-assign-drive` to walk through steps, forking long-running work (implementation, review, release) to isolated agent subprocesses with configurable [execution defaults](.ace-defaults/assign/config.yml) or per-step `fork.provider` overrides. Forks can run sequentially or as parallel batches, each producing inspectable traces and session reports under `.ace-local/assign/`.
+**Run with orchestrator and fork agents** - use `/as-assign-drive` to walk through steps, forking long-running work (implementation, review, release) to isolated agent subprocesses with configurable [execution defaults](.ace-defaults/assign/config.yml) or per-step `fork.provider` overrides. Use `ace-assign watch --assignment <id>` when the driver needs deterministic fork wait/recovery behavior across sequential child subtrees. Forks can run sequentially or as parallel batches, each producing inspectable traces and session reports under `.ace-local/assign/`.
 
 **Recover from failure without losing history** - keep failed-step lineage intact, inject targeted retries or fix steps, and continue execution with auditable failure evidence.
 

--- a/ace-assign/docs/getting-started.md
+++ b/ace-assign/docs/getting-started.md
@@ -126,6 +126,7 @@ ace-assign finish --message report.md --assignment abc123@010.01
 | `ace-assign add --step NAME` | Insert preset step dynamically |
 | `ace-assign retry 040` | Retry failed step as linked work |
 | `ace-assign fork-run --root 010.01` | Execute a subtree in forked context |
+| `ace-assign watch --assignment abc123` | Continue sequential fork work until inline/manual work resumes |
 
 ## Next steps
 

--- a/ace-assign/docs/usage.md
+++ b/ace-assign/docs/usage.md
@@ -218,6 +218,32 @@ Options:
 - `--cli-args <args>`
 - `--timeout <seconds>`
 - `--quiet, -q`
+
+### `ace-assign watch`
+
+Watch active forked assignment work and continue to the next forkable subtree without
+returning control between child completions.
+
+Invocation:
+
+```bash
+ace-assign watch --assignment <id>
+ace-assign watch --assignment <id>@010
+```
+
+Options:
+
+- `--assignment <id>` or `--assignment <id>@<root>`
+- `--root <step-number>`
+- `--poll-interval <seconds>`
+- `--quiet, -q`
+- `--debug, -d`
+
+Behavior:
+
+- Watches existing in-progress forked subtrees and recovers from assignment state after interruption.
+- Launches the next pending fork-enabled subtree immediately after the prior child completes.
+- Stops only when the watched assignment/subtree is complete, failed, or the next runnable step requires inline/manual execution outside the deterministic CLI.
 - `--debug, -d`
 
 Provider resolution precedence for fork execution:

--- a/ace-assign/handbook/skills/as-assign-drive/SKILL.md
+++ b/ace-assign/handbook/skills/as-assign-drive/SKILL.md
@@ -26,7 +26,7 @@ Load and run `ace-bundle wfi://assign/drive` in the current project, then follow
 Hard stop rule:
 
 - Do not stop after intermediate progress.
-- Do not stop while waiting on a forked subtree; keep polling and resume the parent drive loop as soon as the subtree reaches a terminal state.
+- Do not stop while waiting on a forked subtree; `ace-assign watch` owns fork waiting and queue continuation until control legitimately returns to the workflow.
 - Treat `ace-assign status --assignment <id>@<root>` as the source of truth for fork completion; quiet terminal output is not enough reason to stop or declare a stall.
 - If a prior terminal or drive session ended, re-enter from assignment state and continue from the next runnable work instead of depending on the old terminal handle.
 - Before any final response, re-check pinned assignment status. If any runnable `pending` or `in_progress` work remains, continue driving.

--- a/ace-assign/handbook/workflow-instructions/assign/drive.wf.md
+++ b/ace-assign/handbook/workflow-instructions/assign/drive.wf.md
@@ -351,7 +351,7 @@ The driver MUST NOT pause for user input between child fork-runs within a batch 
 1. Verify the child's reports (see Subtree Guard below).
 2. If reports indicate successful completion, immediately launch the next pending child.
 3. Treat the entire batch loop as a single unit of execution -- only pause on quality concerns flagged during report review.
-4. For timeout-constrained environments: launch `fork-run` in background, poll for completion, then loop to the next child without pausing.
+4. Delegate fork waiting and resume logic to `ace-assign watch`; do not hand-roll shell sleep loops inside the workflow.
 
 Conversational boundary rule:
 
@@ -393,21 +393,16 @@ After launching `ace-assign fork-run`, the driver remains inside the same drive 
 
 - Treat "fork subtree is still running" as an internal progress state, not as a stop condition.
 - Do not end the turn, emit a final user-facing completion summary, or hand control back to the user merely because the driver is waiting on fork completion.
-- Poll the forked subtree every 6 minutes by default. Use two signals on each poll:
+- Delegate fork waiting and resume logic to `ace-assign watch`.
+- Treat `ace-assign status` as the source of truth. The watcher may use PID/session telemetry, but queue state remains canonical.
+- Run:
 
-  1. poll the live fork session/process handle
-  2. poll scoped assignment status with `ace-assign status --assignment "${ASSIGNMENT_ID}@${FORK_ROOT}"`
+  ```bash
+  ace-assign watch --assignment "$ASSIGNMENT_TARGET"
+  ```
 
-- Treat scoped assignment status as the source of truth for subtree completion. Terminal PTY output is helpful telemetry, but it is not the canonical completion signal.
-- Continue polling until one of these is true:
-
-  - the `fork-run` process exits
-  - scoped status for the subtree proves every step inside that subtree is terminal (`done` or `failed`)
-  - the workflow reaches a documented blocker or failure path
-
-- If scoped subtree status is terminal, immediately treat the fork as complete even if the PTY stayed quiet or the original terminal handle has already disappeared.
-- A quiet terminal is not a stall by itself. Only treat the fork as stalled when there is no scoped status movement, no new subtree reports, and no process exit for about 30 minutes.
-- When the wait ends, immediately re-enter the parent drive loop. Do not stop between "fork finished" and "next runnable step started."
+- If the watcher returns because the assignment or scoped subtree is complete, continue with the post-fork checklist and then complete the broader workflow if no runnable work remains.
+- If the watcher returns because only inline/manual work remains, immediately continue the main drive loop and execute that work. Do not stop between "watch finished" and "next runnable step started."
 
 #### Post-Fork Resume Checklist
 
@@ -435,28 +430,8 @@ Detached-resume rule:
 Concrete example:
 
 - Incorrect: launch `fork-run` for `040`, post "waiting on subtree", stop responding, and never resume `070`.
-- Correct: launch `fork-run` for `040`, poll until it finishes, review reports, re-check `ace-assign status --assignment "$ASSIGNMENT_TARGET"`, then advance and launch `070` if it is the next runnable step.
+- Correct: launch `fork-run` for `040`, run `ace-assign watch --assignment "$ASSIGNMENT_TARGET"`, review reports, re-check `ace-assign status --assignment "$ASSIGNMENT_TARGET"`, then advance and launch `070` if it is the next runnable step.
 - Correct after interruption: re-run `/as-assign-drive <assignment-id>`, detect that `040` is already terminal from scoped status/reports, then immediately advance and launch `070`.
-
-> **Long-running execution:** `fork-run` typically takes 10-30 minutes depending on subtree complexity. If your environment has bash timeout limits (e.g., Claude Code's 10-minute Bash tool limit), run `fork-run` in background and poll for completion:
->
-> ```bash
-> # Run fork-run in background (use run_in_background: true in Claude Code)
-> ace-assign fork-run --assignment "${ASSIGNMENT_ID}@${FORK_ROOT}" &
->
-> # Poll scoped status every 6 minutes until subtree completes
-> while true; do
->   STATUS_JSON=$(ace-assign status --assignment "${ASSIGNMENT_ID}@${FORK_ROOT}" --format json)
->   COMPLETE=$(echo "$STATUS_JSON" | ruby -rjson -e '
->     json = JSON.parse(STDIN.read)
->     steps = json["steps"] || []
->     puts steps.all? { |step| step["status"] == "done" || step["status"] == "failed" }
->   ')
->   [ "$COMPLETE" = "true" ] && break
->   sleep 360
-> done
-> ace-assign status --assignment "$ASSIGNMENT_TARGET"
-> ```
 
 #### Subtree Completion: Task Status Verification
 

--- a/ace-assign/lib/ace/assign/cli.rb
+++ b/ace-assign/lib/ace/assign/cli.rb
@@ -49,6 +49,7 @@ require_relative "cli/commands/retry_cmd"
 require_relative "cli/commands/list"
 require_relative "cli/commands/select"
 require_relative "cli/commands/fork_run"
+require_relative "cli/commands/watch"
 
 module Ace
   module Assign
@@ -70,7 +71,8 @@ module Ace
         ["retry", "Retry failed step"],
         ["list", "List all assignments"],
         ["select", "Select active assignment"],
-        ["fork-run", "Run subtree in forked process"]
+        ["fork-run", "Run subtree in forked process"],
+        ["watch", "Watch and continue forked assignment work"]
       ].freeze
 
       HELP_EXAMPLES = [
@@ -80,7 +82,8 @@ module Ace
         "ace-assign start                      # Start next workable step",
         "ace-assign finish --message done.md    # Complete active step",
         "cat report.md | ace-assign finish     # Complete step via stdin",
-        "ace-assign fork-run 010.01            # Run subtree in subprocess"
+        "ace-assign fork-run 010.01            # Run subtree in subprocess",
+        "ace-assign watch --assignment abc123  # Continue forked queue work"
       ].freeze
 
       # Captured command exit code from last run
@@ -127,6 +130,7 @@ module Ace
       register "list", wrap_command(Commands::List)
       register "select", wrap_command(Commands::Select)
       register "fork-run", wrap_command(Commands::ForkRun)
+      register "watch", wrap_command(Commands::Watch)
 
       # Register version command
       version_cmd = Ace::Support::Cli::VersionCommand.build(

--- a/ace-assign/lib/ace/assign/cli/commands/watch.rb
+++ b/ace-assign/lib/ace/assign/cli/commands/watch.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module Ace
+  module Assign
+    module CLI
+      module Commands
+        # Watches fork-enabled assignment work and continues through the next
+        # forkable subtree without handing control back to the caller between
+        # child completions. It intentionally stops when only inline/manual work
+        # remains because that work belongs to /as-assign-drive rather than the
+        # deterministic CLI.
+        class Watch < Ace::Support::Cli::Command
+          include Ace::Support::Cli::Base
+          include AssignmentTarget
+
+          DEFAULT_POLL_INTERVAL = 300
+
+          desc "Watch active forked work and continue to the next forkable subtree"
+
+          option :root, desc: "Watch a specific fork subtree root step number (e.g., 010.01)"
+          option :assignment, desc: "Target specific assignment ID"
+          option :poll_interval, type: :integer, default: DEFAULT_POLL_INTERVAL, desc: "Polling interval in seconds while a fork session is still running"
+          option :quiet, aliases: ["-q"], type: :boolean, default: false, desc: "Suppress non-essential output"
+          option :debug, aliases: ["-d"], type: :boolean, default: false, desc: "Show debug output"
+
+          def initialize(fork_runner: nil, sleeper: nil, pid_alive_checker: nil)
+            super()
+            @fork_runner = fork_runner || method(:run_fork_subtree)
+            @sleeper = sleeper || ->(seconds) { sleep(seconds) }
+            @pid_alive_checker = pid_alive_checker || method(:pid_alive?)
+          end
+
+          def call(**options)
+            poll_interval = normalize_poll_interval(options[:poll_interval])
+            target = resolve_assignment_target(options)
+            executor = build_executor_for_target(target)
+            watch_root = resolve_watch_root(executor, target, options[:root])
+            announced = false
+
+            loop do
+              result = executor.status
+              assignment = result[:assignment]
+              state = result[:state]
+
+              root_step = watch_root ? state.find_by_number(watch_root) : nil
+              announce_watch_scope(assignment.id, watch_root, quiet: options[:quiet]) unless announced || options[:quiet]
+              announced = true
+
+              fail_for_failed_state!(state, root_step)
+
+              if watch_complete?(state, root_step)
+                puts completion_message(assignment.id, watch_root) unless options[:quiet]
+                return
+              end
+
+              if (active_root = active_fork_root(state, root_step))
+                if fork_session_alive?(active_root)
+                  puts "Waiting #{poll_interval}s for fork subtree #{active_root.number} to finish..." unless options[:quiet]
+                  sleeper.call(poll_interval)
+                  next
+                end
+
+                puts "Recovering fork subtree #{active_root.number} from assignment state..." unless options[:quiet]
+                fork_runner.call(active_root.number, assignment.id, quiet: options[:quiet], debug: options[:debug])
+                next
+              end
+
+              if (pending_root = pending_fork_root(state, root_step))
+                puts "Launching fork subtree #{pending_root.number}..." unless options[:quiet]
+                fork_runner.call(pending_root.number, assignment.id, quiet: options[:quiet], debug: options[:debug])
+                next
+              end
+
+              puts stop_message(assignment.id, state, root_step) unless options[:quiet]
+              return
+            end
+          end
+
+          private
+
+          attr_reader :fork_runner, :sleeper, :pid_alive_checker
+
+          def normalize_poll_interval(value)
+            raw = value
+            raw = DEFAULT_POLL_INTERVAL if raw.nil? || raw.to_s.strip.empty?
+            seconds = raw.to_i
+            raise Ace::Support::Cli::Error, "--poll-interval must be greater than 0" if seconds <= 0
+
+            seconds
+          end
+
+          def resolve_watch_root(executor, target, explicit_root)
+            if explicit_root && target.scope && explicit_root.to_s.strip != target.scope.to_s.strip
+              raise Ace::Support::Cli::Error, "Conflicting subtree roots: --root #{explicit_root} and scope #{target.scope}"
+            end
+
+            root_number = explicit_root.to_s.strip
+            root_number = target.scope.to_s.strip if root_number.empty?
+            return nil if root_number.empty?
+
+            state = executor.status[:state]
+            root_step = state.find_by_number(root_number)
+            raise StepErrors::NotFound, "Step #{root_number} not found in queue" unless root_step
+            raise Ace::Support::Cli::Error, "Step #{root_step.number} is not fork-enabled (context: fork missing)." unless root_step.fork?
+
+            root_step.number
+          end
+
+          def fail_for_failed_state!(state, root_step)
+            if root_step
+              return unless state.subtree_failed?(root_step.number)
+
+              failed_refs = state.subtree_steps(root_step.number)
+                .select { |step| step.status == :failed }
+                .map { |step| "#{step.number}(#{step.name})" }
+              raise Ace::Support::Cli::Error, "Fork subtree #{root_step.number} failed: #{failed_refs.join(', ')}"
+            end
+
+            return unless state.failed.any?
+
+            failed_refs = state.failed.map { |step| "#{step.number}(#{step.name})" }
+            raise Ace::Support::Cli::Error, "Assignment has failed step(s): #{failed_refs.join(', ')}"
+          end
+
+          def watch_complete?(state, root_step)
+            if root_step
+              state.subtree_complete?(root_step.number)
+            else
+              state.complete?
+            end
+          end
+
+          def active_fork_root(state, root_step)
+            current = if root_step
+              state.current_in_subtree(root_step.number)
+            else
+              state.current
+            end
+            return nil unless current
+
+            state.nearest_fork_ancestor(current.number)
+          end
+
+          def pending_fork_root(state, root_step)
+            next_step = if root_step
+              state.next_workable_in_subtree(root_step.number)
+            else
+              state.next_workable
+            end
+            return nil unless next_step
+
+            next_step.fork? ? next_step : state.nearest_fork_ancestor(next_step.number)
+          end
+
+          def fork_session_alive?(root_step)
+            candidate_pids = [root_step.fork_launch_pid, *Array(root_step.fork_tracked_pids)].compact.uniq
+            candidate_pids.any? { |pid| pid_alive_checker.call(pid) }
+          end
+
+          def pid_alive?(pid)
+            Process.kill(0, Integer(pid))
+            true
+          rescue Errno::ESRCH, Errno::EPERM, TypeError, ArgumentError
+            false
+          end
+
+          def run_fork_subtree(root_number, assignment_id, quiet:, debug:)
+            Commands::ForkRun.new.call(
+              root: root_number,
+              assignment: assignment_id,
+              quiet: quiet,
+              debug: debug
+            )
+          end
+
+          def announce_watch_scope(assignment_id, watch_root, quiet:)
+            return if quiet
+
+            if watch_root
+              puts "Watching fork subtree #{watch_root} in assignment #{assignment_id}."
+            else
+              puts "Watching assignment #{assignment_id} for forked continuation."
+            end
+          end
+
+          def completion_message(assignment_id, watch_root)
+            if watch_root
+              "Fork subtree #{watch_root} is complete for assignment #{assignment_id}."
+            else
+              "Assignment #{assignment_id} is complete."
+            end
+          end
+
+          def stop_message(assignment_id, state, root_step)
+            current = root_step ? state.current_in_subtree(root_step.number) : state.current
+            next_step = root_step ? state.next_workable_in_subtree(root_step.number) : state.next_workable
+
+            if current
+              "No fork work remains to watch for assignment #{assignment_id}. Current step #{current.number} (#{current.name}) requires inline/manual execution."
+            elsif next_step
+              "No fork work remains to watch for assignment #{assignment_id}. Next step #{next_step.number} (#{next_step.name}) requires inline/manual execution."
+            elsif root_step
+              "Fork subtree #{root_step.number} has no remaining fork work to watch."
+            else
+              "Assignment #{assignment_id} has no remaining fork work to watch."
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-001-multi-assignment.runner.md
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-001-multi-assignment.runner.md
@@ -1,0 +1,23 @@
+# Goal 1 — Multi-Assignment Operator Flow
+
+## Goal
+
+Validate public multi-assignment operations: create two assignments, list them,
+switch selection, and use explicit `--assignment` targeting without mutating
+selection unexpectedly.
+
+## Workspace
+
+Save output to `results/tc/01/`.
+
+## Constraints
+
+- Create two assignments from:
+  - `fixtures/multi/job-a.yaml`
+  - `fixtures/multi/job-b.yaml`
+- Capture both assignment IDs.
+- Verify `ace-assign list --all` shows both assignments.
+- Select assignment A and show status via active-context call.
+- Query assignment B via explicit `--assignment <id>` and verify that explicit targeting does not silently change selected assignment.
+- Clear selection and verify explicit targeting still works for both IDs.
+- All artifacts must come from real tool execution.

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-001-multi-assignment.verify.md
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-001-multi-assignment.verify.md
@@ -1,0 +1,25 @@
+# Goal 1 — Multi-Assignment Operator Flow Verification
+
+## Injected Context
+
+The verifier receives the `results/` directory tree and access to the sandbox path.
+
+## Expectations
+
+Validation order (impact-first):
+1. Confirm sandbox/project state impact first.
+2. Confirm explicit artifacts under `results/tc/01/`.
+3. Use debug evidence only as fallback.
+
+1. **Two assignments created** — evidence includes two distinct assignment IDs.
+2. **List output includes both IDs**.
+3. **Selection behavior works** — selected assignment status reflects active context.
+4. **Explicit targeting works** — `--assignment <id>` status queries the intended assignment.
+5. **Selection isolation** — explicit targeting does not unexpectedly overwrite active selection.
+
+## Verdict
+
+- **PASS**: Multi-assignment list/select/target operations behave as documented.
+- **FAIL**: Missing assignment visibility, targeting mismatch, or selection corruption.
+
+Report: `PASS` or `FAIL` with evidence (IDs, list/status outputs).

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-002-fork-run-delegation.runner.md
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-002-fork-run-delegation.runner.md
@@ -1,0 +1,22 @@
+# Goal 2 — Fork-Run Delegated Subtree
+
+## Goal
+
+Exercise scoped fork delegation with `ace-assign fork-run --assignment <id>@<root>`
+and verify user-visible subtree behavior.
+
+## Workspace
+
+Save output to `results/tc/02/`.
+
+## Constraints
+
+- Create assignment from `fixtures/fork/job.yaml` and capture assignment ID.
+- Capture baseline unscoped status and scoped subtree status for `@020`.
+- Run `ace-assign fork-run --assignment "<id>@020"` and capture output.
+- After command returns, capture scoped and unscoped status again.
+- Acceptable outcomes:
+  - subtree reached terminal completion, OR
+  - command reported explicit provider/tool unavailability while preserving assignment integrity.
+- In both outcomes, evidence must show scoped targeting behavior and no silent mutation outside intended scope.
+- All artifacts must come from real tool execution.

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-002-fork-run-delegation.verify.md
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-002-fork-run-delegation.verify.md
@@ -1,0 +1,27 @@
+# Goal 2 — Fork-Run Delegated Subtree Verification
+
+## Injected Context
+
+The verifier receives the `results/` directory tree and access to the sandbox path.
+
+## Expectations
+
+Validation order (impact-first):
+1. Confirm sandbox/project state impact first.
+2. Confirm explicit artifacts under `results/tc/02/`.
+3. Use debug evidence only as fallback.
+
+1. **Assignment created** — create command succeeded and assignment ID exists.
+2. **Scoped subtree visibility** — scoped status for `@020` shows subtree-focused steps.
+3. **Fork-run attempted** — fork-run command evidence is present.
+4. **Outcome validity** — either:
+   - subtree completion evidence is present, OR
+   - explicit provider/tool-unavailable error is captured.
+5. **State integrity after attempt** — post-attempt status evidence is coherent and does not show unrelated silent mutations.
+
+## Verdict
+
+- **PASS**: Fork-run scoped delegation path was exercised and produced a valid, user-visible outcome with coherent post-state.
+- **FAIL**: Scoped behavior not demonstrated, fork-run attempt missing, or post-state evidence is inconsistent/corrupt.
+
+Report: `PASS` or `FAIL` with evidence (scoped/unscoped status and fork-run output).

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-003-watch-sequential-continuation.runner.md
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-003-watch-sequential-continuation.runner.md
@@ -1,0 +1,23 @@
+# Goal 3 — Watch-Driven Sequential Fork Continuation
+
+## Goal
+
+Exercise `ace-assign watch --assignment <id>` on an assignment that contains
+multiple sequential fork subtrees followed by inline work, and verify that one
+watch invocation advances through the fork steps without requiring manual
+re-invocation between them.
+
+## Workspace
+
+Save output to `results/tc/03/`.
+
+## Constraints
+
+- Create assignment from `fixtures/watch/job.yaml` and capture assignment ID.
+- Capture baseline status before running `watch`.
+- Run `ace-assign watch --assignment "<id>"` and capture output.
+- Capture post-watch status after the command returns.
+- Acceptable outcome:
+  - both sequential fork subtrees are terminal, and
+  - the next runnable step is the inline/manual tail step or the assignment is complete.
+- All artifacts must come from real tool execution.

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-003-watch-sequential-continuation.verify.md
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/TC-003-watch-sequential-continuation.verify.md
@@ -1,0 +1,24 @@
+# Goal 3 — Watch-Driven Sequential Fork Continuation Verification
+
+## Injected Context
+
+The verifier receives the `results/` directory tree and access to the sandbox path.
+
+## Expectations
+
+Validation order (impact-first):
+1. Confirm sandbox/project state impact first.
+2. Confirm explicit artifacts under `results/tc/03/`.
+3. Use debug evidence only as fallback.
+
+1. **Assignment created** — create command succeeded and assignment ID exists.
+2. **Watch invoked** — watch command evidence is present.
+3. **Sequential continuation happened** — post-watch evidence shows the fork subtrees are terminal without requiring a second watch invocation artifact.
+4. **Legitimate stop boundary** — the returned state is coherent: inline/manual work is next, or the assignment is complete.
+
+## Verdict
+
+- **PASS**: Watch-driven continuation is demonstrated with coherent before/after state.
+- **FAIL**: Watch invocation missing, fork children did not advance as expected, or returned state is inconsistent.
+
+Report: `PASS` or `FAIL` with evidence (watch output and before/after status).

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/fixtures/fork/job.yaml
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/fixtures/fork/job.yaml
@@ -1,0 +1,21 @@
+session:
+  name: fork-run-operations
+  description: Scoped fork-run delegation flow
+
+steps:
+  - name: precheck
+    instructions: |
+      Collect baseline status.
+
+  - name: delegated-subtree
+    context: fork
+    instructions: |
+      Execute delegated subtree using fork-run.
+    sub_steps:
+      - onboard
+      - plan-task
+      - work-on-task
+
+  - name: postcheck
+    instructions: |
+      Validate post-fork state.

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/fixtures/multi/job-a.yaml
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/fixtures/multi/job-a.yaml
@@ -1,0 +1,11 @@
+session:
+  name: multi-assignment-a
+  description: Assignment A for operator flow
+
+steps:
+  - name: analyze
+    instructions: |
+      Analyze repository state.
+  - name: verify
+    instructions: |
+      Verify assignment A flow.

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/fixtures/multi/job-b.yaml
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/fixtures/multi/job-b.yaml
@@ -1,0 +1,8 @@
+session:
+  name: multi-assignment-b
+  description: Assignment B for operator flow
+
+steps:
+  - name: prepare
+    instructions: |
+      Prepare assignment B context.

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/fixtures/watch/job.yaml
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/fixtures/watch/job.yaml
@@ -1,0 +1,22 @@
+session:
+  name: watch-sequential-operations
+  description: Sequential fork continuation flow
+
+steps:
+  - name: child-one
+    context: fork
+    instructions: |
+      Execute the first delegated subtree.
+    sub_steps:
+      - do-one
+
+  - name: child-two
+    context: fork
+    instructions: |
+      Execute the second delegated subtree.
+    sub_steps:
+      - do-two
+
+  - name: inline-tail
+    instructions: |
+      This step should remain for the driver after watch completes.

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/runner.yml.md
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/runner.yml.md
@@ -1,0 +1,38 @@
+---
+description: "E2E runner input for ace-assign operations coverage"
+bundle:
+  embed_document_source: true
+  params:
+    output: cache
+    max_size: 81920
+  files:
+    - ./TC-001-multi-assignment.runner.md
+    - ./TC-002-fork-run-delegation.runner.md
+    - ./TC-003-watch-sequential-continuation.runner.md
+---
+
+# E2E Test Runner: ace-assign Operations
+
+Tool under test: ace-assign
+Required tools: ace-assign
+Workspace root: (current directory)
+
+Execute each goal sequentially.
+
+## Rules
+
+- Setup ownership belongs to `scenario.yml` and fixtures; do not re-implement setup in TC runners
+- Execute each goal in order (1 through 3)
+- Use only declared scenario tools (`ace-*` and explicit exceptions from `requires.tools`)
+- Save all artifacts to results/tc/{NN}/ directories as specified
+- Do not assign PASS/FAIL verdicts in runner output
+- Do not fabricate output — all artifacts must come from real tool execution
+- If a goal fails, note the failure and continue to the next goal
+- After all goals, output a brief summary of what you produced for each goal
+
+## Artifact conventions
+
+When a goal requires capturing command output:
+- Save stdout to `{name}.stdout`, stderr to `{name}.stderr`, exit code to `{name}.exit`
+- The `.exit` file contains only the numeric exit code (e.g., `0` or `1`)
+- Summary or analysis files (.md) are optional extras — raw captures are primary artifacts

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/scenario.yml
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/scenario.yml
@@ -1,0 +1,32 @@
+test-id: TS-ASSIGN-003
+title: "ace-assign Multi-Assignment and Fork-Run Operations"
+timeout: 900
+area: assign
+package: ace-assign
+priority: high
+tags: [deep, "use-case:assign", operations]
+cost-tier: happy-path
+tool-under-test: ace-assign
+
+sandbox-layout:
+  results/tc/01/: "Multi-assignment operator flow evidence"
+  results/tc/02/: "Fork-run delegated subtree evidence"
+  results/tc/03/: "Watch-driven sequential fork continuation evidence"
+
+e2e-justification: >
+  Assignment operators rely on explicit assignment targeting and scoped subtree
+  execution. This scenario validates those user-visible operations through real
+  CLI journeys: working with multiple concurrent assignments, executing a
+  fork-enabled subtree using `fork-run` with scoped assignment syntax, and
+  continuing sequential fork children through `watch` without user prompts.
+
+requires:
+  tools: [ace-assign]
+  ruby: ">= 3.0"
+
+setup:
+  - git-init
+  - run: "cp ${ACE_E2E_SOURCE_ROOT:-$PROJECT_ROOT_PATH}/mise.toml mise.toml && mise trust mise.toml"
+  - copy-fixtures
+  - agent-env:
+      PROJECT_ROOT_PATH: .

--- a/ace-assign/test/e2e/TS-ASSIGN-003-operations/verifier.yml.md
+++ b/ace-assign/test/e2e/TS-ASSIGN-003-operations/verifier.yml.md
@@ -1,0 +1,37 @@
+---
+description: "E2E verifier input for ace-assign operations coverage"
+bundle:
+  embed_document_source: true
+  params:
+    output: cache
+    max_size: 81920
+  files:
+    - ./TC-001-multi-assignment.verify.md
+    - ./TC-002-fork-run-delegation.verify.md
+    - ./TC-003-watch-sequential-continuation.verify.md
+---
+
+# E2E Verification: ace-assign Operations
+
+You are an E2E test verifier. You inspect artifacts and render PASS/FAIL verdicts.
+
+## Rules
+
+- Use impact-first verification order:
+  1. sandbox/project state impact
+  2. explicit artifacts under `results/tc/{NN}/`
+  3. debug captures (`stdout`, `stderr`, `.exit`) only as fallback
+- Evaluate each goal independently based solely on the artifacts provided
+- Do not speculate about what the runner did — only judge what exists
+- For each goal, cite specific evidence (filenames, content snippets)
+- Follow the output format exactly
+
+## Output Format
+
+For each goal output:
+
+### Goal N — <title>
+- **Verdict**: PASS | FAIL
+- **Evidence**: <specific file/content citations>
+
+Final line: **Results: X/3 passed**

--- a/ace-assign/test/fast/commands/watch_command_test.rb
+++ b/ace-assign/test/fast/commands/watch_command_test.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class WatchCommandTest < AceAssignTestCase
+  class CompletingForkRunner
+    attr_reader :calls
+
+    def initialize(cache_base:)
+      @cache_base = cache_base
+      @calls = []
+    end
+
+    def call(root_number, assignment_id, quiet:, debug:)
+      @calls << {root_number: root_number, assignment_id: assignment_id, quiet: quiet, debug: debug}
+
+      manager = Ace::Assign::Molecules::AssignmentManager.new(cache_base: @cache_base)
+      assignment = manager.load(assignment_id)
+      executor = Ace::Assign::Organisms::AssignmentExecutor.new(cache_base: @cache_base)
+      executor.assignment_manager.define_singleton_method(:find_active) { assignment }
+
+      report_path = File.join(@cache_base, "watch-report-#{root_number.gsub('.', '_')}.md")
+      File.write(report_path, "Completed #{root_number}")
+
+      loop do
+        state = executor.status[:state]
+        break if state.subtree_complete?(root_number) || state.subtree_failed?(root_number)
+        before = state.subtree_steps(root_number).map { |step| [step.number, step.status] }
+        executor.advance(report_path, fork_root: root_number)
+        after = executor.status[:state].subtree_steps(root_number).map { |step| [step.number, step.status] }
+        raise "test runner made no subtree progress for #{root_number}" if before == after
+      end
+    end
+  end
+
+  def run_watch_command(cache_base:, command: nil, **kwargs)
+    command ||= Ace::Assign::CLI::Commands::Watch.new
+    with_fast_command_executor(command, cache_base: cache_base) do
+      command.call(**kwargs)
+    end
+  end
+
+  def capture_watch_command(cache_base:, command: nil, **kwargs)
+    capture_io do
+      run_watch_command(cache_base: cache_base, command: command, **kwargs)
+    end
+  end
+
+  def test_watch_runs_sequential_fork_children_until_inline_work_remains
+    with_temp_cache do |cache_dir|
+      steps = [
+        {
+          "name" => "child-one",
+          "instructions" => "Fork child one",
+          "context" => "fork",
+          "sub_steps" => %w[do-one]
+        },
+        {
+          "name" => "child-two",
+          "instructions" => "Fork child two",
+          "context" => "fork",
+          "sub_steps" => %w[do-two]
+        },
+        {
+          "name" => "inline-tail",
+          "instructions" => "Manual follow-up"
+        }
+      ]
+      config_path = create_test_config(cache_dir, steps: steps, name: "watch-sequential")
+
+      Ace::Assign.config["cache_dir"] = cache_dir
+      result = build_fast_executor(cache_base: cache_dir).start(config_path)
+      runner = CompletingForkRunner.new(cache_base: cache_dir)
+      command = Ace::Assign::CLI::Commands::Watch.new(
+        fork_runner: runner,
+        sleeper: ->(_seconds) { flunk "did not expect sleep while completing local fork runs" }
+      )
+
+      output = capture_watch_command(
+        cache_base: cache_dir,
+        command: command,
+        assignment: result[:assignment].id
+      )
+
+      assert_equal %w[010 020], runner.calls.map { |call| call[:root_number] }
+      assert_includes output.first, "Watching assignment #{result[:assignment].id} for forked continuation."
+      assert_includes output.first, "No fork work remains to watch"
+      assert_includes output.first, "inline-tail"
+
+      state = build_fast_executor(cache_base: cache_dir).status[:state]
+      assert_equal :done, state.find_by_number("010")&.status
+      assert_equal :done, state.find_by_number("020")&.status
+      assert_equal :pending, state.find_by_number("030")&.status
+
+      Ace::Assign.reset_config!
+    end
+  end
+
+  def test_watch_waits_while_existing_fork_process_is_alive_before_recovering
+    with_temp_cache do |cache_dir|
+      steps = [
+        {
+          "name" => "child-one",
+          "instructions" => "Fork child one",
+          "context" => "fork",
+          "sub_steps" => %w[do-one]
+        }
+      ]
+      config_path = create_test_config(cache_dir, steps: steps, name: "watch-live-pid")
+
+      Ace::Assign.config["cache_dir"] = cache_dir
+      result = build_fast_executor(cache_base: cache_dir).start(config_path)
+      state = build_fast_executor(cache_base: cache_dir).status[:state]
+      root_step = state.find_by_number("010")
+      Ace::Assign::Molecules::StepWriter.new.record_fork_pid_info(
+        root_step.file_path,
+        launch_pid: 42_001,
+        tracked_pids: [42_002]
+      )
+
+      sleeps = []
+      pid_checks = []
+      pid_checker = lambda do |pid|
+        pid_checks << pid
+        sleeps.empty?
+      end
+
+      runner = CompletingForkRunner.new(cache_base: cache_dir)
+      command = Ace::Assign::CLI::Commands::Watch.new(
+        fork_runner: runner,
+        sleeper: ->(seconds) { sleeps << seconds },
+        pid_alive_checker: pid_checker
+      )
+
+      output = capture_watch_command(
+        cache_base: cache_dir,
+        command: command,
+        assignment: result[:assignment].id,
+        root: "010",
+        poll_interval: 12
+      )
+
+      assert_equal [12], sleeps
+      refute_empty pid_checks
+      assert_equal ["010"], runner.calls.map { |call| call[:root_number] }
+      assert_includes output.first, "Waiting 12s for fork subtree 010 to finish..."
+      assert_includes output.first, "Recovering fork subtree 010 from assignment state..."
+
+      Ace::Assign.reset_config!
+    end
+  end
+
+  def test_watch_reports_completed_scoped_subtree_without_launching_runner
+    with_temp_cache do |cache_dir|
+      steps = [
+        {
+          "name" => "fork-root",
+          "instructions" => "Fork child one",
+          "context" => "fork",
+          "sub_steps" => %w[do-one]
+        }
+      ]
+      config_path = create_test_config(cache_dir, steps: steps, name: "watch-scoped-complete")
+
+      Ace::Assign.config["cache_dir"] = cache_dir
+      executor = build_fast_executor(cache_base: cache_dir)
+      result = executor.start(config_path)
+      report_path = create_report(cache_dir, "done")
+      executor.advance(report_path, fork_root: "010")
+
+      runner_called = false
+      command = Ace::Assign::CLI::Commands::Watch.new(
+        fork_runner: lambda do |_root_number, _assignment_id, **_kwargs|
+          runner_called = true
+        end
+      )
+
+      output = capture_watch_command(
+        cache_base: cache_dir,
+        command: command,
+        assignment: "#{result[:assignment].id}@010"
+      )
+
+      refute runner_called
+      assert_includes output.first, "Fork subtree 010 is complete"
+
+      Ace::Assign.reset_config!
+    end
+  end
+
+  def test_watch_rejects_non_fork_root
+    with_temp_cache do |cache_dir|
+      config_path = create_test_config(cache_dir, name: "watch-invalid-root")
+      Ace::Assign.config["cache_dir"] = cache_dir
+      result = build_fast_executor(cache_base: cache_dir).start(config_path)
+
+      error = assert_raises(Ace::Support::Cli::Error) do
+        run_watch_command(cache_base: cache_dir, assignment: result[:assignment].id, root: "010")
+      end
+
+      assert_includes error.message, "not fork-enabled"
+      Ace::Assign.reset_config!
+    end
+  end
+end

--- a/ace-assign/test/fast/organisms/assign_drive_contract_test.rb
+++ b/ace-assign/test/fast/organisms/assign_drive_contract_test.rb
@@ -16,13 +16,13 @@ class AssignDriveContractTest < AceAssignTestCase
   def test_drive_workflow_requires_status_driven_fork_resume
     content = drive_workflow
 
-    assert_includes content, "Poll the forked subtree every 6 minutes by default."
-    assert_includes content, "Treat scoped assignment status as the source of truth for subtree completion."
-    assert_includes content, "ace-assign step --assignment \"$ASSIGNMENT_TARGET\""
-    assert_includes content, "If scoped subtree status is terminal, immediately treat the fork as complete"
+    assert_includes content, "Delegate fork waiting and resume logic to `ace-assign watch`."
+    assert_includes content, "ace-assign watch --assignment \"$ASSIGNMENT_TARGET\""
+    assert_includes content, "Treat `ace-assign status` as the source of truth."
+    assert_includes content, "If the watcher returns because only inline/manual work remains"
     assert_includes content, "If a prior drive session or terminal ended, a new `/as-assign-drive` invocation MUST recover from assignment state"
     assert_includes content, "Correct after interruption: re-run `/as-assign-drive <assignment-id>`"
-    assert_includes content, "sleep 360"
+    refute_includes content, "sleep 360"
   end
 
   def test_drive_skill_remains_a_thin_workflow_wrapper
@@ -30,7 +30,7 @@ class AssignDriveContractTest < AceAssignTestCase
 
     assert_includes content, "workflow: wfi://assign/drive"
     assert_includes content, "Load and run `ace-bundle wfi://assign/drive`"
-    assert_includes content, "source of truth for fork completion"
+    assert_includes content, "`ace-assign watch` owns fork waiting and queue continuation"
     assert_includes content, "re-enter from assignment state"
     refute_includes content, "Planned steps are mandatory work items."
     refute_includes content, "External Action Rule (Attempt-First)"

--- a/docs/decisions/ADR-034-assignment-watch-and-callback-contract.md
+++ b/docs/decisions/ADR-034-assignment-watch-and-callback-contract.md
@@ -1,0 +1,95 @@
+# ADR-034: Assignment Watch and Callback Contract
+
+## Status
+
+Accepted
+Date: 2026-04-15
+
+## Context
+
+`/as-assign-drive` already documented a run-until-complete-or-blocked contract, but fork waiting and child-to-child continuation still depended too heavily on prompt instructions and conversational discipline. In real assignment batches, the driver could finish one child subtree, report progress, and then stop until the user said `continue`, even though the parent queue still had deterministic next work.
+
+Existing building blocks already existed:
+
+- `ace-assign status` provides canonical assignment and subtree state
+- `ace-assign fork-run` executes one fork-enabled subtree
+- fork session metadata and PID traces are persisted under `.ace-local/assign/<assignment-id>/sessions/`
+
+What was missing was a deterministic runtime loop that owned "wait for fork / recover after interruption / launch next child" outside the LLM workflow prompt.
+
+## Decision
+
+We introduce `ace-assign watch` as the deterministic runtime for fork continuation, and we reserve callback delivery as a separate contract layered on top of watcher state.
+
+Key aspects of this decision:
+
+- `ace-assign watch --assignment <id>` is the canonical CLI for waiting on in-flight fork work, recovering from interruption via assignment state, and immediately continuing to the next pending fork subtree.
+- `/as-assign-drive` remains the public orchestration workflow, but it delegates fork wait/resume behavior to `ace-assign watch` instead of hand-rolled polling guidance.
+- `ace-assign status` remains the source of truth. PID/session data may help the watcher decide whether a child is still alive, but status determines completion.
+- `watch` intentionally stops when only inline/manual work remains. It is not a general-purpose executor for arbitrary assignment steps.
+- Callback delivery is defined as a notification layer only; parent agents must still re-check status before acting.
+
+## Callback Contract
+
+Future callback support will target deterministic parent wake-up without replacing status polling as the authority.
+
+Reserved interface:
+
+- `ace-assign watch --callback tmux:<target>`
+- `<target>` accepts standard tmux targets, including explicit pane ids such as `%42`
+
+Reserved events:
+
+- `subtree_completed`
+- `subtree_failed`
+- `assignment_blocked`
+- `assignment_completed`
+
+Reserved payload shape:
+
+- prefix: `ACE_ASSIGN_EVENT `
+- JSON object keys:
+  - `assignment_id`
+  - `scope`
+  - `event`
+  - `current_step`
+  - `next_step`
+  - `session_id`
+  - `report_path_or_dir`
+  - `resume_command`
+  - `timestamp`
+
+Callback rules:
+
+- delivery is best-effort and must not mutate assignment truth
+- callback failure must not fail or corrupt the assignment
+- consumers must re-run `ace-assign status` before deciding what to do next
+
+## Consequences
+
+### Positive
+
+- Sequential fork batches now have a product-level continuation path instead of relying on agent memory.
+- Interrupted drive sessions can recover by re-entering from assignment state.
+- The LLM workflow becomes thinner and easier to verify.
+
+### Negative
+
+- Another CLI surface must be documented and tested.
+- Watch/recovery semantics now depend on persisted fork metadata being kept accurate enough for telemetry.
+
+### Neutral
+
+- `fork-run` remains the single-subtree execution primitive.
+- Inline/manual assignment work still belongs to `/as-assign-drive`, not to the deterministic watcher.
+
+## Related Decisions
+
+- [ADR-028: Assignment Fork Execution and Recovery](ADR-028-assignment-fork-execution-and-recovery.md)
+- [ADR-031: CLI Argument and Execution Contract](ADR-031-cli-argument-and-execution-contract.md)
+
+## References
+
+- `ace-assign/lib/ace/assign/cli/commands/watch.rb`
+- `ace-assign/handbook/workflow-instructions/assign/drive.wf.md`
+- `ace-assign/handbook/skills/as-assign-drive/SKILL.md`


### PR DESCRIPTION
## 📋 Summary

Fork-heavy assignments can now keep moving without a user typing `continue` after every completed child subtree. Before this change, `/as-assign-drive` documented a run-until-done contract, but real execution still depended too much on conversational discipline, so finished fork children could leave the batch paused until the user nudged it forward again.

## ✏️ Changes

- **`ace-assign watch`** adds a deterministic runtime loop that waits on active fork sessions, recovers from assignment state after interruption, and immediately launches the next eligible fork subtree.
- **`/as-assign-drive`** now delegates fork wait/resume behavior to `ace-assign watch` instead of relying on prompt-level polling instructions.
- **`TS-ASSIGN-003`** now covers the public operations suite on this branch, including a new watch-driven sequential continuation scenario alongside the existing multi-assignment and fork-run flows.
- **`8re.t.mh0` draft specs** capture the behavioral contract for permanent continuation and the reserved tmux callback handoff surface.
- **`ADR-034`** records the watcher decision and the notification-only callback contract so later implementation keeps status as the source of truth.

## 📁 File Changes

```text
+1290,   -46   23 files   total

 +722,   -46   18 files      ace-assign/
 +220,    -2    2 files   🧱 lib/
   +6,    -2                 ace/assign/cli.rb
 +214,    -0                 ace/assign/cli/commands/watch.rb
 +462,    -6   11 files   🧪 test/
  +23,    -0                 e2e/TS-ASSIGN-003-operations/TC-001-multi-assignment.runner.md
  +25,    -0                 .../TC-001-multi-assignment.verify.md
  +22,    -0                 .../TC-002-fork-run-delegation.runner.md
  +27,    -0                 .../TC-002-fork-run-delegation.verify.md
  +23,    -0                 .../TC-003-watch-sequential-continuation.runner.md
  +24,    -0                 .../TC-003-watch-sequential-continuation.verify.md
  +38,    -0                 .../runner.yml.md
  +32,    -0                 .../scenario.yml
  +37,    -0                 .../verifier.yml.md
 +205,    -0                 fast/commands/watch_command_test.rb
   +6,    -6                 fast/organisms/assign_drive_contract_test.rb
  +11,   -36    2 files   📚 handbook/
   +1,    -1                 skills/as-assign-drive/SKILL.md
  +10,   -35                 workflow-instructions/assign/drive.wf.md
  +29,    -2    3 files      
   +2,    -2                 README.md
   +1,    -0                 docs/getting-started.md
  +26,    -0                 .../usage.md

 +473,    -0    4 files      .ace-tasks/
 +125,    -0                 8re.t.mh0-harden-assignment-drive-continuation-and/0-spike-deterministic-ace-assign-watch/8re.t.mh0.0-spike-deterministic-ace-assign-watch-continuation.s.md
 +136,    -0                 8re.t.mh0-harden-assignment-drive-continuation-and/1-specify-tmux-callback-notification-contract/8re.t.mh0.1-specify-tmux-callback-notification-contract-for.s.md
 +153,    -0                 8re.t.mh0-harden-assignment-drive-continuation-and/8re.t.mh0-harden-assignment-drive-continuation-and-callback.s.md
  +59,    -0                 8re.t.mh0-harden-assignment-drive-continuation-and/ux/usage.md

  +95,    -0    1 files      ./
  +95,    -0                 docs/decisions/ADR-034-assignment-watch-and-callback-contract.md
```

## 🧪 Test Evidence

- **`ace-test`** in `ace-assign` passed with `549 tests`, `1820 assertions`, `0 failures`, `0 errors`, validating the new watcher command plus the updated drive contract coverage.
- **`ace-test feat`** in `ace-assign` passed with `2 tests`, `46 assertions`, `0 failures`, `0 errors`, validating the feature-level package flow after the watcher changes landed.

## 🎮 Demo

Run the watcher on a fork-heavy assignment:

```bash
ace-assign watch --assignment 8rddnp
```

Expected behavior:
- Waits while an active fork subtree is still running
- Recovers from assignment state if the previous fork session disappeared
- Launches the next eligible fork subtree immediately after child completion
- Stops only when the assignment is complete, blocked/failed, or only inline/manual work remains
