### PR TITLE
8ue.t.bo8: expose neutral agents projection coverage

### DIFF
--- a/.ace-tasks/8ue.t.bo8-align-agents-projection-with-canonical/8ue.t.bo8-align-agents-projection-with-canonical-inventory.s.md
+++ b/.ace-tasks/8ue.t.bo8-align-agents-projection-with-canonical/8ue.t.bo8-align-agents-projection-with-canonical-inventory.s.md
@@ -1,0 +1,197 @@
+---
+id: 8ue.t.bo8
+status: in_progress
+priority: medium
+created_at: "2026-07-15 07:46:55"
+estimate: TBD
+dependencies: []
+tags: [handbook, skills, agents, projection]
+github_issue: 307
+bundle:
+  presets: [project]
+  files: [ace-handbook/.ace-defaults/handbook/providers/agents.yml, ace-handbook/docs/usage.md, ace-handbook/lib/ace/handbook/atoms/provider_registry.rb, ace-handbook/lib/ace/handbook/organisms/skill_inventory.rb, ace-handbook/lib/ace/handbook/molecules/skill_projection.rb, ace-handbook/lib/ace/handbook/organisms/provider_syncer.rb, ace-handbook/lib/ace/handbook/organisms/status_collector.rb, ace-handbook/test/fast/organisms/skill_inventory_test.rb, ace-handbook/test/fast/organisms/provider_syncer_test.rb, ace-handbook/test/fast/organisms/status_collector_test.rb, ace-handbook/test/e2e/TS-HANDBOOK-002-sync-behavior/scenario.yml, ace-handbook/test/e2e/TS-HANDBOOK-002-sync-behavior/TC-003-default-agents-projection.verify.md, .ace-tasks/8ue.t.bo8-align-agents-projection-with-canonical/ux/usage.md]
+  commands: [ace-task show 8ue.t.bo8 --content, ace-handbook sync, ace-handbook status, ace-handbook status --format json, ace-handbook sync --provider codex, ace-test ace-handbook, ace-test-e2e ace-handbook TS-HANDBOOK-002]
+needs_review: false
+---
+
+# Align agents projection with canonical inventory
+
+## Behavioral Specification
+
+### User Experience
+
+- **Input:** A developer or agent installs the ACE handbook skill sources and runs the documented default `ace-handbook sync`.
+- **Process:** ACE treats the neutral `agents` provider as the default projection for common ACE workflow skills. It includes skills compatible with the documented default policy, including legacy full-provider targets, while keeping intentionally narrow provider-specific skills scoped. Sync and status evaluate the same effective expected set and report its coverage against the canonical inventory.
+- **Output:** `.agents/skills/` contains the effective expected skills, including `as-git-commit`, and `ace-handbook status` explains when the projection is curated instead of reporting a falsely complete canonical projection.
+
+### Expected Behavior
+
+1. A default sync projects every skill in the documented effective `agents` policy into `.agents/skills/`, including skills whose metadata targets the legacy full provider set (`claude`, `codex`, `gemini`, `opencode`, and `pi`).
+2. Intentionally narrow provider-specific targets remain excluded from the neutral projection unless they explicitly opt into `agents`; explicit provider sync continues to honor those narrow targets.
+3. The neutral `agents` projection has a dynamic expected set derived from the canonical inventory and the documented policy; exact global skill counts are not part of the user-facing contract.
+4. `as-git-commit` is a required sentinel: when `ace-git-commit` is installed and discovered, `.agents/skills/as-git-commit/SKILL.md` is present after default sync.
+5. `ace-handbook status` uses the exact expected skill set that default sync would write. After a clean sync, expected, installed, and in-sync counts agree, with zero missing, outdated, or extra entries.
+6. When the effective expected set is smaller than the canonical inventory, status explicitly reports a curated projection policy, the excluded count, and the reason or policy boundary; a file-level clean projection must not appear to mean that every canonical skill is projected.
+7. Provider-specific frontmatter overrides remain isolated to their requested provider. The neutral projection contains the canonical skill contract without unrelated provider override metadata.
+8. Explicit provider sync remains provider-specific: `ace-handbook sync --provider codex` writes only the Codex projection and continues honoring Codex targeting and overrides.
+
+### Interface Contract
+
+```bash
+ace-handbook sync
+# Expected: default sync reports the agents projection and its dynamic skill count.
+# Expected: .agents/skills/<canonical-skill>/SKILL.md exists for every effective expected skill.
+# Expected: .agents/skills/as-git-commit/SKILL.md exists when ace-git-commit is installed.
+```
+
+```bash
+ace-handbook status
+# Expected: canonical inventory and agents expected-set metrics are shown together.
+# Expected after a clean sync: missing=0, outdated=0, extra=0, and in_sync=expected.
+# Expected when canonical total exceeds expected: the output identifies a curated policy, excluded count, and reason.
+# Expected table output: the agents row exposes the policy mode and excluded count, with a human-readable reason when curated.
+```
+
+```bash
+ace-handbook status --format json
+# Expected: machine-readable canonical inventory, provider metrics, and projection coverage fields.
+# Expected agents provider fields: projection_policy (complete|curated), excluded_count, and policy_reason.
+```
+
+```bash
+ace-handbook sync --provider codex
+# Expected: writes only the Codex provider projection and does not update .agents/skills/.
+```
+
+Error Handling:
+
+- Unknown providers continue to return a non-zero result with the existing actionable unknown-provider error.
+- Disabled providers requested explicitly continue to return a non-zero result with the existing disabled-provider error.
+
+Edge Cases:
+
+- A clean sync from an empty `.agents/skills/` directory and a sync over stale entries converge on the same effective expected set.
+- Canonical inventory growth changes dynamic counts but does not require hard-coded expected totals.
+- Provider-specific frontmatter overrides are absent from the neutral projection and present only in the explicitly requested provider projection.
+- An intentionally curated deployment reports the excluded-skill boundary consistently in sync and status.
+
+## Success Criteria
+
+- [x] Default sync projects the complete effective `agents` policy; no common workflow skill is silently omitted because of legacy provider target metadata.
+- [x] A clean default sync makes `as-git-commit` available whenever `ace-git-commit` is installed and discovered.
+- [x] `ace-handbook status` and `ace-handbook sync` agree on the exact expected set and report a clean state after sync without false extras or hidden missing skills.
+- [x] Any intentional difference between canonical total and `agents` expected count is explicitly identified in status with a curated policy, excluded count, and reason or policy boundary.
+- [x] Explicit provider sync continues to write only the requested provider projection and preserves provider-specific targeting and frontmatter isolation.
+- [x] Fast tests cover default projection membership, narrow-target handling, status/sync agreement, stale cleanup, filtering disclosure, and failure handling.
+- [x] The retained handbook sync E2E scenario verifies default projection output, status output, sentinel availability, and clean exit behavior; full execution is blocked by the dedicated sandbox precondition documented below.
+
+## Validation Questions
+
+- No pending human-input questions for the draft. Repository research resolved the policy choice: `agents` is the neutral surface for common workflow skills, while intentionally narrow provider targets remain provider-specific; any resulting canonical-versus-expected gap must be observable.
+- Exact canonical totals are intentionally not fixed because the inventory changes across ACE releases.
+- Explicit provider projections remain a separate contract from the neutral default and must not be broadened as a side effect.
+
+## Vertical Slice Decomposition Task/Subtask Model
+
+- **Slice type:** Standalone task.
+- **Slice outcome:** A default ACE setup exposes the complete effective common-workflow projection through `.agents/skills/`, and status truthfully reports projection coverage against the canonical inventory.
+- **Advisory size:** Medium.
+- **Context dependencies:** GitHub issue 307, the agents provider manifest, canonical skill inventory discovery, projection rules, sync/status collectors, the handbook sync E2E scenario, and task-local usage scenarios.
+
+## Verification Plan
+
+### Unit/Component Validation
+
+- Given multiple canonical sources and skills with legacy full-provider targets, verify the neutral `agents` expected set includes every common workflow skill and preserves the projected skill body.
+- Given the same inventory, verify sync and status compute identical skill names and counts.
+- Given a canonical skill with an intentionally narrow provider target, verify it remains excluded from `agents` while remaining available to its explicit provider.
+- Given canonical total greater than `agents` expected, verify status exposes the curated policy, excluded count, and reason or policy boundary.
+- Verify provider-specific overrides do not appear in the neutral projection and remain available for the explicitly requested provider.
+- Verify stale entries are removed only when they are outside the declared expected set.
+
+### Integration/E2E Validation If Cross-Boundary Behavior Exists
+
+- Run default sync in a clean sandbox, inspect the generated `.agents/skills/` tree for `as-git-commit` and representative skills from multiple sources, then run status.
+- Confirm status reports the same expected set that sync maintained and has no missing, outdated, or extra entries after the clean sync.
+- Confirm a scenario with intentionally narrow targets reports curated coverage rather than implying that expected equals canonical.
+- Run explicit Codex sync and confirm only `.codex/skills/` changes for that invocation.
+- Exercise JSON status output so automation can distinguish file-level sync from intentionally curated coverage.
+
+### Failure/Invalid Path Validation
+
+- Request an unknown provider and confirm the existing non-zero error contract remains intact.
+- Request a disabled provider and confirm the existing non-zero error contract remains intact.
+- Exercise a documented curated subset and confirm sync and status disclose the same filtered boundary.
+
+### Verification Commands
+
+- `ace-test ace-handbook`
+- `ace-test-e2e ace-handbook TS-HANDBOOK-002 --dry-run`
+- `ace-test-e2e ace-handbook TS-HANDBOOK-002`
+
+## Objective
+
+Make the documented default ACE setup trustworthy. When canonical skill sources are installed and available, agents should receive the complete common-workflow projection under `.agents/skills/`, and handbook status should make coverage against the canonical inventory visible instead of reporting a clean-looking hidden subset.
+
+## Scope of Work
+
+- Define the neutral `agents` provider's common-workflow projection contract.
+- Align default sync and status around one dynamic expected skill set.
+- Make intentional filtering visible to users and automation.
+- Preserve explicit provider projection behavior and provider-specific frontmatter isolation.
+- Add sentinel and cross-source verification for `as-git-commit` and representative canonical skills.
+
+## Deliverables
+
+### Behavioral Specifications
+
+- Complete common-workflow projection behavior for the neutral `agents` provider.
+- Sync/status consistency and transparency contract.
+- Curated projection coverage behavior.
+- Preservation of explicit provider projection semantics.
+
+### Validation Artifacts
+
+- Fast tests for projection membership, status/sync agreement, filtering disclosure, and failure paths.
+- Retained handbook sync E2E coverage for default and explicit provider behavior.
+- Task-local usage scenarios for sync, status, JSON status, and error/curated cases.
+
+## Out of Scope
+
+- Rewriting canonical skill content or changing individual skill instructions.
+- Restoring provider-specific folders as the default output.
+- Changing explicit provider-specific frontmatter semantics except where required to keep neutral projection metadata clean.
+- Fixing unrelated handbook resources or non-skill sync behavior.
+- Changing the documented common-workflow policy to project every canonical skill.
+- Redesigning canonical source discovery or error recovery.
+- Hard-coding a fixed canonical skill count into behavior or acceptance criteria.
+
+## References
+
+- GitHub issue 307: `https://github.com/cs3b/ace/issues/307`
+- Issue report: `ace-handbook sync` reports 32 installed/expected agents skills while canonical inventory reports 90, silently removing 58 skills including `as-git-commit`.
+- Issue environment evidence: all 22 direct `ace-*` dependencies are loaded with `missing=0`, so a clean file-level status must not hide a smaller provider expectation than the canonical inventory.
+- Repository research: `ace-handbook/docs/usage.md`, ADR-027, and completed task `8tt.t.stj` define `agents` as the neutral surface for common workflow skills, not an unconditional mirror of every canonical skill.
+- Local verification: current checkout reports canonical `99`, agents expected `99`, installed `99`, in-sync `99`; issue #307 is not reproducible in this workspace, so acceptance uses the dynamic coverage invariant rather than fixed local counts.
+- `ace-handbook/.ace-defaults/handbook/providers/agents.yml`
+- `ace-handbook/lib/ace/handbook/atoms/provider_registry.rb`
+- `ace-handbook/lib/ace/handbook/organisms/skill_inventory.rb`
+- `ace-handbook/lib/ace/handbook/molecules/skill_projection.rb`
+- `ace-handbook/lib/ace/handbook/organisms/provider_syncer.rb`
+- `ace-handbook/lib/ace/handbook/organisms/status_collector.rb`
+- `ace-git-commit/handbook/skills/as-git-commit/SKILL.md`
+- `ace-handbook/test/e2e/TS-HANDBOOK-002-sync-behavior/scenario.yml`
+- `.ace-tasks/8tt.t.stj-project-default-ace-workflow-skills/8tt.t.stj-project-default-ace-workflow-skills-into-agents.s.md`
+
+## Verification Results
+
+- `ace-test ace-handbook`: passed, 32 tests, 178 assertions, 0 failures.
+- `ace-test-e2e ace-handbook TS-HANDBOOK-002 --dry-run`: passed, three test cases discovered.
+- `ace-test-e2e ace-handbook TS-HANDBOOK-002`: blocked before scenario execution because the dedicated Ruby 3.4.9 sandbox exposes globally installed `ace-*` gems; no scenario assertion ran.
+
+## Review Summary
+
+**Readiness Checklist:** complete after reconciling the draft with the documented common-workflow projection policy
+**Questions Generated:** 1 high-priority ambiguity resolved through repository docs, ADR-027, completed task 8tt.t.stj, and current status output
+**Critical Blockers:** none remain
+**Decision:** Ready for implementation planning; the task now specifies curated coverage disclosure rather than requiring an unconditional all-canonical default

--- a/.ace-tasks/8ue.t.bo8-align-agents-projection-with-canonical/ux/usage.md
+++ b/.ace-tasks/8ue.t.bo8-align-agents-projection-with-canonical/ux/usage.md
@@ -1,0 +1,72 @@
+# Align agents projection with canonical inventory - Draft Usage
+
+## API Surface
+
+- [x] CLI (user-facing commands)
+- [ ] Developer API (modules, classes)
+- [x] Agent API (workflows, protocols, slash commands)
+- [ ] Configuration (config keys, env vars)
+
+## Usage Scenarios
+
+### Scenario 1: Project common workflows by default
+
+**Goal**: Give agents access to every available common ACE workflow skill through the neutral default provider.
+
+```bash
+ace-handbook sync
+```
+
+### Expected Output
+
+- The command reports a successful `agents` projection with a dynamic count matching the effective common-workflow policy.
+- `.agents/skills/as-git-commit/SKILL.md` exists when `ace-git-commit` is installed and discovered.
+- Representative skills from every available common-workflow source are present under `.agents/skills/`.
+
+### Scenario 2: Verify that status describes the projection sync maintains
+
+**Goal**: Detect missing, stale, extra, filtered, or incomplete skill projections accurately.
+
+```bash
+ace-handbook status
+ace-handbook status --format json
+```
+
+### Expected Output
+
+- The canonical inventory and the `agents` expected set are both visible.
+- After a clean sync, the status reports zero missing, outdated, and extra entries, with in-sync equal to expected.
+- If canonical total exceeds the expected set because of intentional provider targeting, the output identifies the curated policy, excluded count, and policy boundary instead of implying that every canonical skill is projected.
+
+### Scenario 3: Keep explicit provider sync isolated
+
+**Goal**: Allow a project to request a provider-native projection without changing the neutral default projection.
+
+```bash
+ace-handbook sync --provider codex
+```
+
+### Expected Output
+
+- The command writes only the Codex projection under `.codex/skills/`.
+- `.agents/skills/` is not updated by the explicit Codex invocation.
+- Codex-specific targeting and frontmatter overrides remain scoped to the Codex output.
+
+### Scenario 4: Report curated projection coverage
+
+**Goal**: Make an intentional difference between canonical inventory and default projection visible to users and automation.
+
+```text
+ace-handbook status --format json
+```
+
+### Expected Output
+
+- The provider entry reports the effective projection policy, excluded count, and policy boundary.
+- The canonical total and expected count remain machine-readable so automation can distinguish file-level sync from inventory coverage.
+- The status does not claim that a smaller curated projection is a complete canonical mirror.
+
+## Notes for Implementer
+
+- Use dynamic inventory and sentinel assertions rather than fixed global skill counts.
+- Full usage documentation should be completed during work-on-task using `wfi://docs/update-usage`.

--- a/ace-handbook/docs/usage.md
+++ b/ace-handbook/docs/usage.md
@@ -88,6 +88,7 @@ ace-test-e2e ace-handbook
 ```
 
 Notes:
+
 - `ace-test ace-handbook` targets deterministic tests in `test/fast`.
 - `ace-test ace-handbook feat` is only needed when feature-layer deterministic tests exist in `test/feat`.
 - `ace-test-e2e ace-handbook` is reserved for scenario workflows in `test/e2e`.
@@ -133,6 +134,12 @@ ace-handbook sync
 ace-handbook sync --provider codex
 ace-handbook status --provider codex --format json
 ```
+
+`ace-handbook status` also reports neutral-projection coverage. For the `agents` provider, table output includes
+`POLICY` and `EXCLUDED` columns, while JSON includes `projection_policy`, `excluded_count`, and `policy_reason`.
+`projection_policy: complete` means every canonical skill is in the effective default projection. When provider-specific
+targeting intentionally narrows the neutral projection, status reports `projection_policy: curated`, the excluded count,
+and the reason instead of presenting the file-level projection as a complete canonical mirror.
 
 Unknown provider IDs are a public error contract and should fail with a non-zero exit plus an `Unknown provider: ...`
 message:

--- a/ace-handbook/lib/ace/handbook/organisms/status_collector.rb
+++ b/ace-handbook/lib/ace/handbook/organisms/status_collector.rb
@@ -35,6 +35,9 @@ module Ace
               entry.fetch("outdated").to_s,
               entry.fetch("missing").to_s,
               entry.fetch("extra").to_s,
+              entry.fetch("projection_policy", "").to_s,
+              entry.fetch("excluded_count", "").to_s,
+              entry.fetch("policy_reason", "").to_s,
               entry.fetch("relative_output_dir")
             ]
           end
@@ -48,19 +51,20 @@ module Ace
             ["IN_SYNC", *rows.map { |row| row[5] }].map(&:length).max,
             ["OUTDATED", *rows.map { |row| row[6] }].map(&:length).max,
             ["MISSING", *rows.map { |row| row[7] }].map(&:length).max,
-            ["EXTRA", *rows.map { |row| row[8] }].map(&:length).max
+            ["EXTRA", *rows.map { |row| row[8] }].map(&:length).max,
+            ["POLICY", *rows.map { |row| row[9] }].map(&:length).max,
+            ["EXCLUDED", *rows.map { |row| row[10] }].map(&:length).max,
+            ["REASON", *rows.map { |row| row[11] }].map(&:length).max
           ]
 
-          header = format(
-            "%-#{widths[0]}s  %-#{widths[1]}s  %-#{widths[2]}s  %#{widths[3]}s  %#{widths[4]}s  %#{widths[5]}s  %#{widths[6]}s  %#{widths[7]}s  %#{widths[8]}s  %s",
-            "PROVIDER", "ENABLED", "TYPE", "EXPECTED", "INSTALLED", "IN_SYNC", "OUTDATED", "MISSING", "EXTRA", "PATH"
-          )
-          lines = rows.map do |provider, enabled, type, expected, installed, in_sync, outdated, missing, extra, path|
-            format(
-              "%-#{widths[0]}s  %-#{widths[1]}s  %-#{widths[2]}s  %#{widths[3]}s  %#{widths[4]}s  %#{widths[5]}s  %#{widths[6]}s  %#{widths[7]}s  %#{widths[8]}s  %s",
-              provider, enabled, type, expected, installed, in_sync, outdated, missing, extra, path
-            )
+          right_aligned = (3..8).to_a + [10]
+          formats = widths.each_index.map do |index|
+            right_aligned.include?(index) ? "%#{widths[index]}s" : "%-#{widths[index]}s"
           end
+          table_format = formats.join("  ")
+          headers = %w[PROVIDER ENABLED TYPE EXPECTED INSTALLED IN_SYNC OUTDATED MISSING EXTRA POLICY EXCLUDED REASON PATH]
+          header = format(table_format, *headers)
+          lines = rows.map { |row| format(table_format, *row) }
 
           (summary_lines + ["", header] + lines).join("\n")
         end
@@ -102,7 +106,7 @@ module Ace
             end
           end
 
-          {
+          status = {
             "provider" => provider,
             "enabled" => provider_enabled?(provider),
             "relative_output_dir" => relative_output_dir,
@@ -115,6 +119,19 @@ module Ace
             "outdated" => outdated,
             "missing" => (expected.keys - installed_names).size,
             "extra" => extra
+          }
+
+          status.merge!(projection_coverage(skills, expected)) if provider == "agents"
+          status
+        end
+
+        def projection_coverage(skills, expected)
+          excluded_count = skills.size - expected.size
+
+          {
+            "projection_policy" => excluded_count.zero? ? "complete" : "curated",
+            "excluded_count" => excluded_count,
+            "policy_reason" => excluded_count.zero? ? nil : "provider-specific targeting"
           }
         end
 

--- a/ace-handbook/lib/ace/handbook/organisms/status_collector.rb
+++ b/ace-handbook/lib/ace/handbook/organisms/status_collector.rb
@@ -54,7 +54,8 @@ module Ace
             ["EXTRA", *rows.map { |row| row[8] }].map(&:length).max,
             ["POLICY", *rows.map { |row| row[9] }].map(&:length).max,
             ["EXCLUDED", *rows.map { |row| row[10] }].map(&:length).max,
-            ["REASON", *rows.map { |row| row[11] }].map(&:length).max
+            ["REASON", *rows.map { |row| row[11] }].map(&:length).max,
+            ["PATH", *rows.map { |row| row[12] }].map(&:length).max
           ]
 
           right_aligned = (3..8).to_a + [10]

--- a/ace-handbook/test/e2e/TS-HANDBOOK-002-sync-behavior/TC-003-default-agents-projection.verify.md
+++ b/ace-handbook/test/e2e/TS-HANDBOOK-002-sync-behavior/TC-003-default-agents-projection.verify.md
@@ -20,6 +20,6 @@ legacy-targeted workflow skill available in that neutral provider tree.
 - `results/tc/03/status-agents.exit` is `0`
 - `results/tc/03/sync-agents.stdout` includes `synced agents -> .agents/skills`
 - `.agents/skills/as-git-commit/SKILL.md` exists when `ace-git-commit` skills are installed in the sandbox
-- If `as-git-commit` is not installed in the sandbox, at least one installed common workflow skill from the legacy
-  full-provider target set exists under `.agents/skills`
+- If `as-git-commit` is not installed in the sandbox, at least one installed common workflow skill from the legacy full-provider target set exists under `.agents/skills`
 - `results/tc/03/status-agents.stdout` does not report the projected legacy-targeted workflow skill as an extra entry
+- `results/tc/03/status-agents.stdout` includes `POLICY` and `EXCLUDED` coverage columns for the default `agents` row

--- a/ace-handbook/test/fast/organisms/status_collector_test.rb
+++ b/ace-handbook/test/fast/organisms/status_collector_test.rb
@@ -128,8 +128,21 @@ class Ace::Handbook::Organisms::StatusCollectorTest < Minitest::Test
     assert_equal 4, provider.fetch("installed")
     assert_equal 4, provider.fetch("in_sync")
     assert_equal 0, provider.fetch("extra")
+    assert_equal "curated", provider.fetch("projection_policy")
+    assert_equal 1, provider.fetch("excluded_count")
+    assert_equal "provider-specific targeting", provider.fetch("policy_reason")
     assert File.exist?(File.join(@tmpdir, ".agents", "skills", "as-git-commit", "SKILL.md"))
     refute File.exist?(File.join(@tmpdir, ".agents", "skills", "as-codex-only", "SKILL.md"))
+  end
+
+  def test_default_agents_status_reports_complete_coverage
+    snapshot = collector.collect
+    provider = snapshot.fetch("providers").first
+
+    assert_equal "agents", provider.fetch("provider")
+    assert_equal "complete", provider.fetch("projection_policy")
+    assert_equal 0, provider.fetch("excluded_count")
+    assert_nil provider.fetch("policy_reason")
   end
 
   def test_collect_explicit_provider_reports_codex_when_not_default
@@ -153,6 +166,14 @@ class Ace::Handbook::Organisms::StatusCollectorTest < Minitest::Test
     assert_includes output, "IN_SYNC"
     assert_includes output, "ace-task"
     assert_includes output, "pi"
+  end
+
+  def test_to_table_includes_agents_projection_coverage
+    output = collector.to_table(collector.collect)
+
+    assert_includes output, "POLICY"
+    assert_includes output, "EXCLUDED"
+    assert_includes output, "complete"
   end
 
   private

--- a/ace-handbook/test/fast/organisms/status_collector_test.rb
+++ b/ace-handbook/test/fast/organisms/status_collector_test.rb
@@ -164,8 +164,10 @@ class Ace::Handbook::Organisms::StatusCollectorTest < Minitest::Test
     assert_includes output, "SOURCE"
     assert_includes output, "EXPECTED"
     assert_includes output, "IN_SYNC"
+    assert_includes output, "PATH"
     assert_includes output, "ace-task"
     assert_includes output, "pi"
+    assert_includes output, ".pi/skills"
   end
 
   def test_to_table_includes_agents_projection_coverage


### PR DESCRIPTION
## 📋 Summary

Agents and reviewers can now see whether the default `.agents/skills/` projection is complete or intentionally curated. Previously, `ace-handbook status` could report a clean file projection while hiding a gap between the canonical inventory and the effective default projection.

## ✏️ Changes

- **Agents coverage metadata** reports `projection_policy`, `excluded_count`, and `policy_reason` for the neutral `agents` provider.
- **Status table output** exposes `POLICY`, `EXCLUDED`, and `REASON` alongside existing sync metrics.
- **Regression coverage** verifies complete and curated projections, narrow provider targets, and the retained default-sync E2E contract.
- **Usage documentation** explains how to interpret canonical-versus-expected coverage.

## 📁 File Changes

```text
 +327,   -13    6 files   total

  +58,   -13    4 files      ace-handbook/
  +28,   -11    1 files   🧱 lib/
  +28,   -11                 ace/handbook/organisms/status_collector.rb
  +23,    -2    2 files   🧪 test/
   +2,    -2                 e2e/TS-HANDBOOK-002-sync-behavior/TC-003-default-agents-projection.verify.md
  +21,    -0                 fast/organisms/status_collector_test.rb
   +7,    -0    1 files      
   +7,    -0                 docs/usage.md

 +269,    -0    2 files      .ace-tasks/
 +197,    -0                 8ue.t.bo8-align-agents-projection-with-canonical/8ue.t.bo8-align-agents-projection-with-canonical-inventory.s.md
  +72,    -0                 8ue.t.bo8-align-agents-projection-with-canonical/ux/usage.md
```

## 🧪 Test Evidence

- **Ace::Handbook::Organisms::StatusCollectorTest** validates complete coverage, curated coverage, narrow targets, sync/status alignment, and table rendering.
- **ace-test ace-handbook**: 32 tests, 178 assertions, 0 failures.
- **ace-test ace-handbook --profile 20**: 32 tests, 178 assertions, 0 failures; total test time 0.350s.
- **ace-test-e2e ace-handbook TS-HANDBOOK-002 --dry-run**: three test cases discovered successfully.
- Full E2E execution is blocked before scenario setup because the dedicated Ruby 3.4.9 sandbox exposes globally installed `ace-*` gems; no scenario assertion failed.

## 🎮 Demo

```bash
ace-handbook sync
ace-handbook status
```

Observed in the workspace:

- `synced agents -> .agents/skills (99 skills, 1 updated, 1 removed)`
- `agents`: 99 expected, 99 installed, 99 in sync, 0 missing, 0 outdated, 0 extra
- `.agents/skills/as-git-commit/SKILL.md` is present
